### PR TITLE
highlight PHP code

### DIFF
--- a/Book/classes_objects/magic_interfaces_comparable.rst
+++ b/Book/classes_objects/magic_interfaces_comparable.rst
@@ -125,6 +125,8 @@ sense):
 
 .. code-block:: php
 
+    <?php
+
     class Point implements Comparable {
         protected $x, $y, $z;
 


### PR DESCRIPTION
just adding the php open tag for highlighting like other php code blocks 😄  
( it seems that only this php code block is not highlighted.)