### PR TITLE
Drop spaces before interpunction signs

### DIFF
--- a/Book/php7/build_system/building_extensions.rst
+++ b/Book/php7/build_system/building_extensions.rst
@@ -317,10 +317,10 @@ to recompile extensions against a newer PHP version.
     
     Too many numbers? Yes. One API number, bound to one PHP version, would really be enough for anybody and would ease 
     the understanding of PHP versionning. Unfortunately, we got 3 different API numbers in addition to the PHP version 
-    itself. Which one should you look for ? The answer is any : they all-three-of-them evolve when PHP version evolve.
+    itself. Which one should you look for? The answer is any : they all-three-of-them evolve when PHP version evolve.
     For historical reasons, we got 3 different numbers.
     
-But, you are a C developper anren't you ? Why not build a "compatibility" header on your side, based on such number ?
+But, you are a C developper anren't you? Why not build a "compatibility" header on your side, based on such number?
 We authors, use something like this in extensions of ours::
 
     #include "php.h"
@@ -356,9 +356,9 @@ We authors, use something like this in extensions of ours::
     #define IS_PHP_5 1
     #endif
     
-See ?
+See?
 
-Or, simpler (so better ?) is to use PHP_VERSION_ID which you are probably much more familiar about::
+Or, simpler (so better) is to use PHP_VERSION_ID which you are probably much more familiar about::
     
     #if PHP_VERSION_ID >= 50600
     

--- a/Book/php7/extensions_design/php_functions.rst
+++ b/Book/php7/extensions_design/php_functions.rst
@@ -32,7 +32,7 @@ Here it is::
 You can spot that this structure is not complex. This is all you'll need to declare and register a new function.
 Let's detail it together:
 
-A function's got a name: ``fname``. Nothing to add, you see what it's used for right ? Just notice the ``const char *`` 
+A function's got a name: ``fname``. Nothing to add, you see what it's used for right? Just notice the ``const char *`` 
 type. That can't fit into the engine. This ``fname`` is a model and the engine will create from it an 
 :doc:`interned zend_string<../internal_types/strings/zend_strings>`.
 
@@ -259,7 +259,7 @@ zval, and you are expected to play with it. :doc:`Here are more resources about 
 .. note:: While programming PHP functions in C extensions, you receive the return value as an argument, and you don't 
           return anything from your C function body.
 
-Ok first point explained. Second one as you may have guessed: where are the PHP function arguments ? Where is 
+Ok first point explained. Second one as you may have guessed: where are the PHP function arguments? Where is 
 ``$fahreinheit``? That one is pretty hard to fully explain, it is hell hard to in fact.
 
 But we don't need to have a look at the details here. Let's explain the crucial concepts:

--- a/Book/php7/internal_types/strings/zend_strings.rst
+++ b/Book/php7/internal_types/strings/zend_strings.rst
@@ -33,7 +33,7 @@ known. Please, note that the length computes the number of ASCII chars (bytes) n
 counting the eventual middle NULs. For example, the string "foo" is stored as "foo\\0" in a ``zend_string`` and its 
 length is then 3. Also, the string "foo\\0bar" will be stored as "foo\\0bar\\0" and the length will be 7.
 
-Finally, the characters are stored into the ``char[1]`` field. This is not a ``char *``, but a ``char[1]``. Why that ? 
+Finally, the characters are stored into the ``char[1]`` field. This is not a ``char *``, but a ``char[1]``. Why that? 
 This is a memory optimization known as "C struct hack" (you may use a search engine with these terms). Basically, that 
 allows the engine to allocate space for the ``zend_string`` structure and the characters to be stored, as one solo C 
 pointer. This optimizes memory accesses as memory will be a contiguous allocated block, and not two blocks sparsed in 
@@ -284,7 +284,7 @@ Say you want to create the string "foo". What you tend to do is simply create a 
     
     /* ... */
     
-But a question arises : Hasn't that piece of string already been created before you need it ?
+But a question arises : Hasn't that piece of string already been created before you need it?
 When you need a string, you code is executed at some point in PHP's life, that means that some piece of code happening 
 before yours may have needed the exact same piece of string ("foo" for our example).
 

--- a/Book/php7/internal_types/zend_resources.rst
+++ b/Book/php7/internal_types/zend_resources.rst
@@ -12,8 +12,8 @@ makes use of it in its heart or in some extensions. Let's see that type together
 and suffers from a long past history, so don't be suprised about its design especially when reading the source code 
 about it
 
-What is the "Resource" type ?
------------------------------
+What is the "Resource" type?
+----------------------------
 
 Easy enough you know about it. We are talking about this here:
 

--- a/Book/php7/memory_management/memory_debugging.rst
+++ b/Book/php7/memory_management/memory_debugging.rst
@@ -282,7 +282,7 @@ a crash.
 
 Valgrind could also report invalid reads. That means you perform a memory read operation out of the bounds of an 
 allocated pointer. Better scenario that a block overwrite, you still access memory area you should not, and here again 
-in such a scenario that could lead to an immediate crash, or later, or never ? Don't do that.
+in such a scenario that could lead to an immediate crash, or later, or never? Don't do that.
 
 .. note:: As soon as you read "Invalid" in the output of valgrind, that smells really bad for you. Whether invalid 
           read or write, you have a problem in your code, and you should consider this problem as high risk: fix it 

--- a/Book/php7/memory_management/zend_memory_manager.rst
+++ b/Book/php7/memory_management/zend_memory_manager.rst
@@ -18,7 +18,7 @@ PHP is a share-nothing architecture. Well, not at 100%. Let us explain.
           here, you'll get additionnal informations about the different steps and cycles that can be drawn from PHP 
           lifetime.
 
-PHP can treat several (dozen, thousands ?) of requests into the same process. By default, PHP will forget anything it 
+PHP can treat several (dozen, thousands?) of requests into the same process. By default, PHP will forget anything it 
 knows of the current request, when that later finishes.
 
 "Forgetting" things translates to freeing any dynamic buffer that got allocated while treating a request. That means 
@@ -35,11 +35,11 @@ default, PHP forgets *a very huge number* of informations from one request to an
 
 There exists however some pretty rare informations you need to persist across several requests. But that's uncommon.
 
-What could be kept unchanged through requests ? What we call **persistent** objects. Once more let us insist : those 
+What could be kept unchanged through requests? What we call **persistent** objects. Once more let us insist : those 
 are rare cases. For example, the current PHP executable path won't change from requests to requests. That latter 
 information is allocated permanently, that means it is allocated with a traditionnal libc's ``malloc()`` call.
 
-What else ? Some strings. For example, the *"_SERVER"* string will be reused from request to request, as every request 
+What else? Some strings. For example, the *"_SERVER"* string will be reused from request to request, as every request 
 will create the ``$_SERVER`` PHP array. So the *"_SERVER"* string itself can be permanently allocated, because it will 
 be allocated once.
 


### PR DESCRIPTION
I know it is how these signs should be written in French, but it's not allowed in English.