### PR TITLE
fix the duplicate label building_php warning

### DIFF
--- a/Book/php7/build_system/building_php.rst
+++ b/Book/php7/build_system/building_php.rst
@@ -1,6 +1,6 @@
 .. highlight:: bash
 
-.. _building_php:
+.. _building_php_7:
 
 Building PHP
 ============


### PR DESCRIPTION
hot fix for the next warning -at building the book as html stage-:

> WARNING: duplicate label building_php. other instance .....