### PR TITLE
Fix potential bug

### DIFF
--- a/Book/hashtables/hashtable_api.rst
+++ b/Book/hashtables/hashtable_api.rst
@@ -613,7 +613,7 @@ The checker function takes the target hashtable, the source data, its hash key a
 ``zend_hash_apply_with_argument()``). As an example lets implement a function that takes two arrays, merges them and
 in case of a key collision uses the greater value::
 
-    static int merge_greater(
+    static zend_bool merge_greater(
         HashTable *target_ht, zval **source_zv, zend_hash_key *hash_key, void *dummy
     ) {
         zval **target_zv;


### PR DESCRIPTION
Considering the following example

```c
#include <stdio.h>
#include <stdlib.h>
#include <stdbool.h>

typedef int (*foo_pt)(void);
typedef bool (*bar_pt)(void);

static int test(void);

int
main(void)
{
    int result;
    bar_pt func;

    func = (bar_pt)test;

    result = func();

    if (result)
        printf("true\n");
    else
        printf("false\n");

    exit(0);
}

static int
test(void)
{
    return 0x800;
}
```

If we run the program above, we will get **false**. The reason is that the return type
of the declaration (`func` is of `bar_pt` type which returns `bool`) and the definition's
(`test` is of `foo_pt` type which returns `int`) are of different size. As a result, the
returned value would be truncated, thus results undefined behavior.

> If you run this program in a `big-endian machine`, the result may be different


In **PHP 5**, `zend_bool` is defined as

    typedef unsigned char zend_bool;

`merge_checker_func_t` is defined as

    typedef zend_bool (*merge_checker_func_t)(HashTable *target_ht, void *source_data, zend_hash_key *hash_key, void *pParam);

Since the size of `zend_bool` and the size of `int` are different, casting
the function pointer of `merge_greater` to `merge_checker_func_t`
might cause undefined behavior when `merge_greater` is called.
