### PR TITLE
Fix typos

### DIFF
--- a/Book/classes_objects/custom_object_storage.rst
+++ b/Book/classes_objects/custom_object_storage.rst
@@ -27,7 +27,7 @@ its simpler cousins is used::
     zval *obj;
     MAKE_STD_ZVAL(obj);
     object_init(obj);
-    // = object_init_ex(obj, NULL) = object_and_properties_init(obj, NULL, NULL)
+    // = object_init_ex(obj, zend_standard_class_def) = object_and_properties_init(obj, zend_standard_class_def, NULL)
 
 In the last case, i.e. when you are creating an ``stdClass`` object you will probably want to add properties afterwards.
 This usually isn't done with the ``zend_update_property`` functions from the previous chapter, instead the

--- a/Book/hashtables/hashtable_api.rst
+++ b/Book/hashtables/hashtable_api.rst
@@ -613,7 +613,7 @@ The checker function takes the target hashtable, the source data, its hash key a
 ``zend_hash_apply_with_argument()``). As an example lets implement a function that takes two arrays, merges them and
 in case of a key collision uses the greater value::
 
-    static int merge_greater(
+    static zend_bool merge_greater(
         HashTable *target_ht, zval **source_zv, zend_hash_key *hash_key, void *dummy
     ) {
         zval **target_zv;


### PR DESCRIPTION
When [`object_init`](https://github.com/php/php-src/blob/PHP-5.6.39/Zend/zend_API.c#L1213) is used directly, [`zend_standard_class_def`](https://github.com/php/php-src/blob/PHP-5.6.39/Zend/zend_API.c#L1213) is used by default. 

> [`zend_standard_class_def`](https://github.com/php/php-src/blob/PHP-5.6.39/Zend/zend_API.c#L1213) is initialized at [here](https://github.com/php/php-src/blob/PHP-5.6.39/Zend/zend_builtin_functions.c#L318)