### PR TITLE
Put PHP 7 chapters on top, because PHP 5 is not maintained anymore.

### DIFF
--- a/Book/index.rst
+++ b/Book/index.rst
@@ -1,34 +1,11 @@
 Table Of Contents
 =================
 
-PHP 5
------
-
-.. toctree::
-    :maxdepth: 2
-
-    introduction.rst
-    build_system.rst
-
-* Creating PHP extensions
-
-.. toctree::
-    :maxdepth: 2
-
-    zvals.rst
-
-* Implementing functions
-
-.. toctree::
-    :maxdepth: 2
-
-    hashtables.rst
-    classes_objects.rst
-
 PHP 7
 -----
 
-This part concerns only the PHP 7 branch. It is under development.
+This part concerns the current stable branches of PHP based on Zend Engine
+Version 3. You can find internals for Zend Version 2 (PHP 5) below.
 
 .. toctree::
     :maxdepth: 3
@@ -56,6 +33,31 @@ This part concerns only the PHP 7 branch. It is under development.
     php7/sapis.rst
     php7/zend_engine.rst
     php7/final.rst
+
+PHP 5
+-----
+
+.. toctree::
+    :maxdepth: 2
+
+    introduction.rst
+    build_system.rst
+
+* Creating PHP extensions
+
+.. toctree::
+    :maxdepth: 2
+
+    zvals.rst
+
+* Implementing functions
+
+.. toctree::
+    :maxdepth: 2
+
+    hashtables.rst
+    classes_objects.rst
+
 
 Testing PHP Source
 ------------------


### PR DESCRIPTION
I think it makes sense to put PHP 7 on top, PHP 5 is not that important anymore. Of course people need to maintain old extensions, or even have extensions that work on both Zend Engine versions, but its important to put the current stable on top.