### PR TITLE
Start with Hooks provided by PHP chapter.

### DIFF
--- a/Book/php7/extensions_design.rst
+++ b/Book/php7/extensions_design.rst
@@ -16,6 +16,7 @@ Contents:
     extensions_design/php_functions.rst
     extensions_design/globals_management.rst
     extensions_design/extension_infos.rst
+    extensions_design/hooks.rst
     extensions_design/ini_settings.rst
     extensions_design/zend_extensions.rst
 

--- a/Book/php7/extensions_design/hooks.rst
+++ b/Book/php7/extensions_design/hooks.rst
@@ -1,0 +1,172 @@
+Hooks provided by PHP
+=====================
+
+PHP and the Zend Engine provide many different hooks for extensions that allow
+extension developers to control the PHP runtime in ways that are not available
+from PHP userland.
+
+This chapter will show various hooks and common use-cases for hooking into them
+from an extension.
+
+The general pattern for hooking into PHP functionality are extensions
+overwriting function pointers that the PHP core provides. The extension
+function then often performs their own work and calls the original PHP core
+function. Using this pattern different extensions can overwrite the same hook
+without causing conflicts.
+
+Hooking into the execution of functions
+***************************************
+
+The execution of userland and internal functions are handled by two functions
+within the Zend engine that you can replace with your own implementations.
+The primary use-case for extensions to overwrite this hook is generic
+function-level profiling, debugging and aspect oriented programming.
+
+The hooks are defined in ``Zend/zend_execute.h``::
+
+    ZEND_API extern void (*zend_execute_ex)(zend_execute_data *execute_data);
+    ZEND_API extern void (*zend_execute_internal)(zend_execute_data *execute_data, zval *return_value);
+
+If you want to overwrite these function pointers, then you must do this in
+MINIT, because other decisions inside the Zend Engine are made early based on
+the fact if the pointers are overwritten or not.
+
+The usual pattern for overwriting is this::
+
+    static void (*original_zend_execute_ex) (zend_execute_data *execute_data);
+    static void (*original_zend_execute_internal) (zend_execute_data *execute_data, zval *return_value);
+    ZEND_DLEXPORT void my_execute_internal(zend_execute_data *execute_data, zval *return_value);
+    ZEND_DLEXPORT void my_execute_ex (zend_execute_data *execute_data);
+
+    PHP_MINIT_FUNCTION(my_extension)
+    {
+        REGISTER_INI_ENTRIES();
+
+        original_zend_execute_internal = zend_execute_internal;
+        zend_execute_internal = my_execute_internal;
+
+        original_zend_execute_ex = zend_execute_ex;
+        zend_execute_ex = my_execute_ex;
+
+        return SUCCESS;
+    }
+
+    PHP_MSHUTDOWN_FUNCTION(my_extension)
+    {
+        zend_execute_internal = original_zend_execute_internal;
+        zend_execute_ex = original_zend_execute_ex;
+
+        return SUCCESS;
+    }
+
+One downside of overwriting ``zend_execute_ex`` is that it changes the Zend
+Virtual Machine runtime behavior to use recursion instead of a hybrid mode that
+uses goto/switch. In addition a PHP engine without overwritten
+``zend_execute_ex`` can also generate more optimized function call opcodes.
+
+These hooks are very performance sensitive depending on the complexity of code
+that wraps the original functions.
+
+Overwriting an Internal Function
+********************************
+
+While overwriting the execute hooks an extension can record **every** function
+call, you can also overwrite individual function pointers of userland core and
+extension functions (and methods). This has much better performance
+characteristics if an extension only needs access to specific internal function
+calls.::
+
+    #if PHP_VERSION_ID >= 70300
+    #define EXT_FASTCALL ZEND_FASTCALL
+    #else
+    #define EXT_FASTCALL
+    #endif
+
+    #if PHP_VERSION_ID < 70200
+    typedef void (*zif_handler)(INTERNAL_FUNCTION_PARAMETERS);
+    #endif
+    zif_handler original_handler_var_dump;
+
+    void EXT_FASTCALL my_overwrite_var_dump(INTERNAL_FUNCTION_PARAMETERS)
+    {
+        // if we want to call the original function
+        original_handler_var_dump(INTERNAL_FUNCTION_PARAM_PASSTHRU);
+    }
+
+    PHP_MINIT_FUNCTION(my_extension)
+    {
+        zend_function *original;
+
+        original = zend_hash_str_find_ptr(EG(function_table), "var_dump", sizeof("var_dump")-1);
+
+        if (original != NULL) {
+            original_handler_var_dump = original->internal_function.handler;
+            original->internal_function.handler = my_overwrite_var_dump;
+        }
+    }
+
+When overwriting a class method, then the function table can be found on the
+``zend_class_entry``.::
+
+    zend_class_entry *ce = zend_hash_str_find_ptr(CG(class_table), "PDO", sizeof("PDO")-1);
+    if (ce != NULL) {
+        original = zend_hash_str_find_ptr(&ce->function_table, "exec", sizeof("exec")-1);
+
+        if (original != NULL) {
+            original_handler_pdo_exec = original->internal_function.handler;
+            original->internal_function.handler = my_overwrite_pdo_exec;
+        }
+    }
+
+Modifying the Abstract Syntax Tree (AST)
+****************************************
+
+When PHP 7 compiles PHP code it converts it into an abstract syntax tree (AST)
+before finally generating Opcodes that are persisted in Opcache. One lesser
+known hook is called ``zend_ast_process`` for every compiled script and allows
+you to modify the AST after it is parsed and created.
+
+This is one of the most complicated hooks to use, because it requires perfect
+understanding of the AST possibilities. Creating an invalid AST here can cause
+weird behaivor.
+
+It is best to look at example extensions that use this hook:
+
+- `Google Stackdriver PHP Debugger Extension
+  <https://github.com/GoogleCloudPlatform/stackdriver-debugger-php-extension/blob/master/stackdriver_debugger_ast.c>`_
+- Based on Stackdriver this `Proof of Concept Tracer with AST <https://github.com/beberlei/php-ast-tracer-poc/blob/master/astracer.c>`_
+
+Hooking into Script/File Compilation
+************************************
+
+TODO
+
+Hooking into eval()
+*******************
+
+TODO
+
+Hooking into the Garbage Collector
+**********************************
+
+TODO
+
+Replacing Opcode Handlers
+*************************
+
+TODO
+
+Notification when Exception is thrown
+*************************************
+
+TODO
+
+Notification when Error Handler is called
+*****************************************
+
+TODO
+
+Overwrite Interrupt Handler
+***************************
+
+TODO

--- a/Book/php7/extensions_design/hooks.rst
+++ b/Book/php7/extensions_design/hooks.rst
@@ -166,10 +166,12 @@ implementation of the hook.
 It is very important to always call the original function pointer, otherwise
 PHP cannot compile scripts anymore and Opcache will not work anymore.
 
-The extension overwriting order here is also important as you need to be
-careful whether you register your hook before or after Opcache, because
-Opcache does not call the original function pointer if it finds an opcode array
-entry in its shared memory cache.
+The extension overwriting order here is also important as you need to be aware
+whether you want to register your hook before or after Opcache, because Opcache
+does not call the original function pointer if it finds an opcode array entry
+in its shared memory cache. Opcache registers their hook as a post startup
+hook, which runs after the minit phase for extensions, so by default your hook
+will not be called anymore when the script gets cached.
 
 Notification when Error Handler is called
 *****************************************

--- a/Book/php7/extensions_design/hooks.rst
+++ b/Book/php7/extensions_design/hooks.rst
@@ -105,7 +105,7 @@ calls.::
         }
     }
 
-When overwriting a class method, then the function table can be found on the
+When overwriting a class method, the function table can be found on the
 ``zend_class_entry``.::
 
     zend_class_entry *ce = zend_hash_str_find_ptr(CG(class_table), "PDO", sizeof("PDO")-1);

--- a/Book/php7/extensions_design/hooks.rst
+++ b/Book/php7/extensions_design/hooks.rst
@@ -269,19 +269,82 @@ tracking.
 Hooking into eval()
 *******************
 
-TODO
+PHPs ``eval`` is not an internal function but a special language construct. As
+such you cannot hook into it through ``zend_execute_internal`` or by
+overwriting its function pointer.
+
+Use cases for hooking into eval are not that many, you can use it for profiling
+or for security purposes. If you change its behavior be aware that other extensions
+may need eval. One example is Xdebug that uses it to execute breakpoint conditions.
+
+::
+
+    extern ZEND_API zend_op_array *(*zend_compile_string)(zval *source_string, char *filename);
 
 Hooking into the Garbage Collector
 **********************************
 
-TODO
+PHPs Garbage Collector can be triggered explicitly when ``gc_collect_cycles()``
+is called or implicitly by the engine itself when the number of collectable
+objects reaches a certain theshold.
 
-Replacing Opcode Handlers
-*************************
+To allow understanding of how the garabage collector works or to profile its
+performance, you can overwrite the function pointer hook that performs the
+garbage collection operation. Theoretically you can implement your own garbage
+collection algorithm here, but given other changes to the engine would probably
+be necessary this probably is not really feasible.
 
-TODO
+::
+
+    int (*original_gc_collect_cycles)(void);
+
+    int my_gc_collect_cycles(void)
+    {
+        original_gc_collect_cycles();
+    }
+
+    PHP_MINIT_FUNCTION(my_extension)
+    {
+        original_gc_collect_cycles = gc_collect_cycles;
+        gc_collect_cycles = my_gc_collect_cycles;
+
+        return SUCCESS;
+    }
 
 Overwrite Interrupt Handler
 ***************************
+
+The interrupt handler is called once when the executor global
+``EG(vm_interrupt)`` is set to 1. This is checked after every opcode.  The
+engine uses this hook to implement the PHP execution timeout via a signal
+handler that sets the interrupt to 1 after the timeout duration is reached.
+
+You can implement the interrupt helper yourself and trigger it by setting
+``EG(vm_interrupt) = 1`` in your extension.
+
+This can be helpful to implement debuggers, sampling profilers or your own
+timeout handling. By setting this hook you cannot accidently disable the
+timeout check of PHP, because it has a customized handling that has higher
+priority than any ``zend_interrupt_function`` hook overwrite.
+
+::
+
+    ZEND_API void (*original_interrupt_function)(zend_execute_data *execute_data);
+
+    void my_interrupt_function(zend_execute_data *execute_data)
+    {
+        original_interrupt_function(execute_data);
+    }
+
+    PHP_MINIT_FUNCTION(my_extension)
+    {
+        original_interrupt_function = zend_interrupt_function;
+        zend_interrupt_function = my_interrupt_function;
+
+        return SUCCESS;
+    }
+
+Replacing Opcode Handlers
+*************************
 
 TODO

--- a/Book/php7/extensions_design/hooks.rst
+++ b/Book/php7/extensions_design/hooks.rst
@@ -128,7 +128,7 @@ you to modify the AST after it is parsed and created.
 
 This is one of the most complicated hooks to use, because it requires perfect
 understanding of the AST possibilities. Creating an invalid AST here can cause
-weird behaivor.
+weird behavior.
 
 It is best to look at example extensions that use this hook:
 

--- a/Book/php7/extensions_design/hooks.rst
+++ b/Book/php7/extensions_design/hooks.rst
@@ -71,7 +71,7 @@ Overwriting an Internal Function
 ********************************
 
 While overwriting the execute hooks an extension can record **every** function
-call, you can also overwrite individual function pointers of userland core and
+call, you can also overwrite individual function pointers of userland, core and
 extension functions (and methods). This has much better performance
 characteristics if an extension only needs access to specific internal function
 calls.::


### PR DESCRIPTION
Extensions can hook into PHP core in various ways and this chapter is about listing as many of these ways as possible and showing how it works, giving examples, explaining restrictions and downsides.