### PR TITLE
Fix the wrong variable name in iterator sample code that caused memory leak.

### DIFF
--- a/Book/php5/classes_objects/iterators.rst
+++ b/Book/php5/classes_objects/iterators.rst
@@ -185,7 +185,7 @@ Now let's actually implement the ``buffer_view_iterator_funcs`` that we specifie
 
     static void buffer_view_iterator_rewind(zend_object_iterator *intern TSRMLS_DC)
     {
-        buffer_view_iterator *iter = (buffer_view_iterator *) iter;
+        buffer_view_iterator *iter = (buffer_view_iterator *) intern;
 
         iter->offset = 0;
         iter->current = NULL;


### PR DESCRIPTION
Fix the variable name.