### PR TITLE
Change the way to add static stylesheets.

### DIFF
--- a/Book/_templates/layout.html
+++ b/Book/_templates/layout.html
@@ -1,5 +1,4 @@
 {% extends "!layout.html" %}
-{% set css_files = css_files + ["_static/style.css"] %}
 {% block footer %}
     <div class="footer feedback">
         The repository for this book is available on <a href="https://github.com/phpinternalsbook/PHP-Internals-Book">GitHub</a>.

--- a/Book/conf.py
+++ b/Book/conf.py
@@ -37,6 +37,10 @@ extensions = ['sphinx.ext.todo', 'sphinx.ext.ifconfig']
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 
+# Add static stylesheets
+def setup(app):
+    app.add_stylesheet('style.css')
+
 # The suffix of source filenames.
 source_suffix = '.rst'
 


### PR DESCRIPTION
Fix the deprecation warning in build script.

Python 2.7
Sphinx v1.8.5

And the original warning message is as following:
`
/opt/local/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/sphinx/builders/html.py:138: RemovedInSphinx20Warning: builder.css_files is deprecated. Please use app.add_stylesheet() instead.
  ret += other
`