### PR TITLE
Fix sphinx build and update link to sphinx docs

### DIFF
--- a/Book/php5/hashtables/basic_structure.rst
+++ b/Book/php5/hashtables/basic_structure.rst
@@ -27,7 +27,7 @@ illustration of chaining collision resolution:
 
 .. image:: ./images/basic_hashtable.*
    :align: center
-   :height: 265px
+   :height: 265
    :scale: 200%
 
 The elements of the linked list are called ``Bucket``\s and the C array containing the heads of the linked lists is
@@ -41,7 +41,7 @@ pointers in the reverse direction. The latter is what PHP does: Every bucket con
 
 .. image:: ./images/doubly_linked_hashtable.*
    :align: center
-   :height: 250px
+   :height: 250
    :scale: 200%
 
 Furthermore PHP hashtables are *ordered*: If you traverse an array you'll get the elements in same order in which you
@@ -53,7 +53,7 @@ example of how this linked list could look like for the elements ``"a"``, ``"b"`
 
 .. image:: ./images/ordered_hashtable.*
    :align: center
-   :height: 250px
+   :height: 250
    :scale: 200%
 
 The HashTable and Bucket structures

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The book is written using ReStructured Text and generated using Sphinx.
 
  * RST manual: http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html
  * RST quickref: http://docutils.sourceforge.net/docs/user/rst/quickref.html
- * Sphinx manual: http://sphinx.pocoo.org/markup/index.html
+ * Sphinx manual: https://www.sphinx-doc.org/en/master/
 
 Coding style
 ------------


### PR DESCRIPTION
The rendered html `<img height="INT">` is implicitly pixels.
sphinx-build 2.4.4 threw when casting to int().

```
  File "/usr/local/lib/python3.7/site-packages/sphinx/writers/html5.py",
  line 550, in visit_image
      atts['height'] = int(atts['height']) * scale
      ValueError: invalid literal for int() with base 10: '265px'
```

The rendered php5 file had `<img height="500">` for 250px and 200%
scale. (The last svg was 81 pixels tall,
and I'm not familiar with why both height and scale are set)