### PR TITLE
Link to php7 blog posts on compiler/executor

### DIFF
--- a/Book/php7/zend_engine/zend_compiler.rst
+++ b/Book/php7/zend_engine/zend_compiler.rst
@@ -1,2 +1,6 @@
 Zend Compiler
 =============
+
+An example of how to add a syntactic feature to PHP (for updating lexing, adding to PHP's context free grammar, and adding a new opcode) is https://phpinternals.net/articles/implementing_a_range_operator_into_php.
+
+A good introduction to the internals of the Zend virtual machine is https://nikic.github.io/2017/04/14/PHP-7-Virtual-machine.html. This describes the output of the compiler, as well as the way the executor(virtual machine) works.

--- a/Book/php7/zend_engine/zend_executor.rst
+++ b/Book/php7/zend_engine/zend_executor.rst
@@ -1,2 +1,4 @@
 Zend Executor
 =============
+
+A good introduction to the internals of the zend executor (Virtual Machine) is https://nikic.github.io/2017/04/14/PHP-7-Virtual-machine.html


### PR DESCRIPTION
Fixes #77

The PHP7 blog posts for 7.2 are fairly up to date, and a much better starting point for new developers than leaving this empty