### PR TITLE
Add streams documentation

### DIFF
--- a/Book/php7/internal_types.rst
+++ b/Book/php7/internal_types.rst
@@ -16,5 +16,7 @@ Contents:
     internal_types/hashtables.rst
     internal_types/functions.rst
     internal_types/objects.rst
+    internal_types/streams.rst
+
 ..
     internal_types/objects/classes_and_objects.rst

--- a/Book/php7/internal_types/streams.rst
+++ b/Book/php7/internal_types/streams.rst
@@ -1,0 +1,182 @@
+Streams
+=======
+
+Overview
+--------
+
+The PHP Streams API introduces a unified approach to the handling of
+files and sockets in PHP extension.  Using a single API with standard
+functions for common operations, the streams API allows your extension
+to access files, sockets, URLs, memory and script-defined objects.
+Streams is a run-time extensible API that allows dynamically loaded
+modules (and scripts!) to register new streams.
+
+The aim of the Streams API is to make it comfortable for developers to
+open files, URLs and other streamable data sources with a unified API
+that is easy to understand.  The API is more or less based on the ANSI
+C stdio family of functions (with identical semantics for most of the main
+functions), so C programmers will have a feeling of familiarity with streams.
+
+The streams API operates on a couple of different levels: at the base level,
+the API defines php_stream objects to represent streamable data sources.
+On a slightly higher level, the API defines php_stream_wrapper objects
+which "wrap" around the lower level API to provide support for retrieving
+data and meta-data from URLs.  An additional ``context``
+parameter, accepted by most stream creation functions, is passed to the
+wrapper's ``stream_opener`` method to fine-tune the behavior
+of the wrapper.
+
+Any stream, once opened, can also have any number of ``filters``
+applied to it, which process data as it is read from/written to the stream.
+
+Streams can be cast (converted) into other types of file-handles, so that they
+can be used with third-party libraries without a great deal of trouble.  This
+allows those libraries to access data directly from URL sources.  If your
+system has the ``fopencookie`` or
+``funopen`` function, you can even
+pass any PHP stream to any library that uses ANSI stdio!
+
+Streams Basics
+--------------
+
+Using streams is very much like using ANSI stdio functions.  The main
+difference is in how you obtain the stream handle to begin with.
+In most cases, you will use ``php_stream_open_wrapper``
+to obtain the stream handle.  This function works very much like fopen,
+as can be seen from the example below:
+
+Simple stream example that displays the PHP home page::
+
+    php_stream * stream = php_stream_open_wrapper("http://www.php.net", "rb", REPORT_ERRORS, NULL);
+    if (stream) {
+        while(!php_stream_eof(stream)) {
+            char buf[1024];
+            
+            if (php_stream_gets(stream, buf, sizeof(buf))) {
+                printf(buf);
+            } else {
+                break;
+            }
+        }
+        php_stream_close(stream);
+    }
+
+The table below shows the Streams equivalents of the more common ANSI stdio functions.
+Unless noted otherwise, the semantics of the functions are identical.
+
+ANSI stdio equivalent functions in the Streams API
+
++---------------------+-------------------------+------------------------------------------------------+
++ ANSI Stdio Function + PHP Streams Function    + Notes                                                +
++=====================+=========================+======================================================+
++ fopen               + php_stream_open_wrapper + Streams includes additional parameters               +
++---------------------+-------------------------+------------------------------------------------------+
++ fclose              + php_stream_close        +                                                      +
++---------------------+-------------------------+------------------------------------------------------+
++ fgets               + php_stream_gets         +                                                      +
++---------------------+-------------------------+------------------------------------------------------+
++ fread               + php_stream_read         + The nmemb parameter is assumed to have a value of 1, +
++                     +                         + so the prototype looks more like read(2)             +
++---------------------+-------------------------+------------------------------------------------------+
++ fwrite              + php_stream_write        + The nmemb parameter is assumed to have a value of 1, +
++                     +                         + so the prototype looks more like write(2)            +
++---------------------+-------------------------+------------------------------------------------------+
++ fseek               + php_stream_seek         +                                                      +
++---------------------+-------------------------+------------------------------------------------------+
++ ftell               + php_stream_tell         +                                                      +
++---------------------+-------------------------+------------------------------------------------------+
++ rewind              + php_stream_rewind       +                                                      +
++---------------------+-------------------------+------------------------------------------------------+
++ feof                + php_stream_eof          +                                                      +
++---------------------+-------------------------+------------------------------------------------------+
++ fgetc               + php_stream_getc         +                                                      +
++---------------------+-------------------------+------------------------------------------------------+
++ fputc               + php_stream_putc         +                                                      +
++---------------------+-------------------------+------------------------------------------------------+
++ fflush              + php_stream_flush        +                                                      +
++---------------------+-------------------------+------------------------------------------------------+
++ puts                + php_stream_puts         + Same semantics as puts, NOT fputs                    +
++---------------------+-------------------------+------------------------------------------------------+
++ fstat               + php_stream_stat         + Streams has a richer stat structure                  +
++---------------------+-------------------------+------------------------------------------------------+
+
+Streams as Resources
+--------------------
+
+All streams are registered as resources when they are created.  This ensures
+that they will be properly cleaned up even if there is some fatal error.
+All of the filesystem functions in PHP operate on streams resources - that
+means that your extensions can accept regular PHP file pointers as
+parameters to, and return streams from their functions.
+The streams API makes this process as painless as possible:
+
+How to accept a stream as a parameter::
+
+    PHP_FUNCTION(example_write_hello)
+    {
+        zval *zstream;
+        php_stream *stream;
+        
+        if (FAILURE == zend_parse_parameters(ZEND_NUM_ARGS() TSRMLS_CC, "r", &zstream))
+            return;
+        
+        php_stream_from_zval(stream, &zstream);
+
+        /* you can now use the stream.  However, you do not "own" the
+            stream, the script does.  That means you MUST NOT close the
+            stream, because it will cause PHP to crash! */
+
+        php_stream_write(stream, "hello\n");
+            
+        RETURN_TRUE();
+    }
+
+How to return a stream from a function::
+
+    PHP_FUNCTION(example_open_php_home_page)
+    {
+        php_stream *stream;
+        
+        stream = php_stream_open_wrapper("http://www.php.net", "rb", REPORT_ERRORS, NULL);
+        
+        php_stream_to_zval(stream, return_value);
+
+        /* after this point, the stream is "owned" by the script.
+            If you close it now, you will crash PHP! */
+    }
+
+Since streams are automatically cleaned up, it's tempting to think that we can get
+away with being sloppy programmers and not bother to close the streams when we
+are done with them.  Although such an approach might work, it is not a good idea
+for a number of reasons: streams hold locks on system resources while they are
+open, so leaving a file open after you have finished with it could prevent other
+processes from accessing it.  If a script deals with a large number of files,
+the accumulation of the resources used, both in terms of memory and the
+sheer number of open files, can cause web server requests to fail.  Sounds
+bad, doesn't it?  The streams API includes some magic that helps you to
+keep your code clean - if a stream is not closed by your code when it should
+be, you will find some helpful debugging information in you web server error
+log.
+
+.. note::
+    Always use a debug build of PHP when developing an extension
+    (``--enable-debug`` when running configure), as a lot of
+    effort has been made to warn you about memory and stream leaks.
+
+In some cases, it is useful to keep a stream open for the duration of a request,
+to act as a log or trace file for example.  Writing the code to safely clean up
+such a stream is not difficult, but it's several lines of code that are not
+strictly needed.  To save yourself the trouble of writing the code, you
+can mark a stream as being OK for auto cleanup.  What this means is
+that the streams API will not emit a warning when it is time to auto-cleanup
+a stream.  To do this, you can use ``php_stream_auto_cleanup``.
+
+.. toctree::
+    :maxdepth: 2
+
+    streams/common.rst
+    streams/dir.rst
+    streams/file.rst
+    streams/socket.rst
+    streams/structs.rst
+    streams/constants.rst

--- a/Book/php7/internal_types/streams/common.rst
+++ b/Book/php7/internal_types/streams/common.rst
@@ -1,0 +1,588 @@
+Streams Common API Reference
+----------------------------
+
+php_stream_stat_path
+^^^^^^^^^^^^^^^^^^^^
+
+Get the status for a file or URL::
+
+    int php_stream_stat_path(char *path, php_stream_statbuf *ssb)
+
+``php_stream_stat_path`` examines the file or URL specified by ``path``
+and returns information such as file size, access and creation times and so on.
+The return value is 0 on success, -1 on error.
+For more information about the information returned, see :ref:`php_stream_statbuf`.
+
+php_stream_stat
+^^^^^^^^^^^^^^^
+
+Get the status for the underlying storage associated with a stream::
+
+    int php_stream_stat(php_stream *stream, php_stream_statbuf *ssb)
+
+``php_stream_stat`` examines the storage to which ``stream``
+is bound, and returns information such as file size, access and creation times and so on.
+The return value is 0 on success, -1 on error.
+For more information about the information returned, see :ref:`php_stream_statbuf`.
+
+php_stream_open_wrapper
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Open a stream on a file or URL::
+
+    php_stream *php_stream_open_wrapper(char *path, char *mode, int options, char **opened)
+
+``php_stream_open_wrapper`` opens a stream on the file, URL or
+other wrapped resource specified by ``path``.  Depending on
+the value of ``mode``, the stream may be opened for reading,
+writing, appending or combinations of those. See the table below for the different
+modes that can be used; in addition to the characters listed below, you may
+include the character 'b' either as the second or last character in the mode string.
+The presence of the 'b' character informs the relevant stream implementation to
+open the stream in a binary safe mode.
+
+The 'b' character is ignored on all POSIX conforming systems which treat
+binary and text files in the same way.  It is a good idea to specify the 'b'
+character whenever your stream is accessing data where the full 8 bits
+are important, so that your code will work when compiled on a system
+where the 'b' flag is important.
+
+Any local files created by the streams API will have their initial permissions set
+according to the operating system defaults - under Unix based systems
+this means that the umask of the process will be used.  Under Windows,
+the file will be owned by the creating process.
+Any remote files will be created according to the URL wrapper that was
+used to open the file, and the credentials supplied to the remote server.
+
+``r``
+    Open text file for reading.  The stream is positioned at the beginning of
+    the file.
+
+``r+``
+    Open text file for reading and writing.  The stream is positioned at the beginning of
+    the file.
+
+``w``
+    Truncate the file to zero length or create text file for writing.
+    The stream is positioned at the beginning of the file.
+
+``w+``
+    Open text file for reading and writing.  The file is created if
+    it does not exist, otherwise it is truncated. The stream is positioned at
+    the beginning of the file.
+
+``a``
+    Open for writing.  The file is created if it does not exist.
+    The stream is positioned at the end of the file.
+
+``a+``
+    Open text file for reading and writing.  The file is created if
+    it does not exist. The stream is positioned at the end of the file.
+
+``options`` affects how the path/URL of the stream is
+interpreted, safe mode checks and actions taken if there is an error during opening
+of the stream.  See :ref:`streams_open_options` for
+more information about options.
+
+If ``opened`` is not NULL, it will be set to a string containing
+the name of the actual file/resource that was opened.  This is important when the
+options include ``USE_PATH``, which causes the include_path to be searched for the
+file.  You, the caller, are responsible for calling ``efree`` on
+the filename returned in this parameter.
+
+.. note::
+    If you specified ``STREAM_MUST_SEEK`` in ``options``,
+    the path returned in ``opened`` may not be the name of the
+    actual stream that was returned to you.  It will, however, be the name of the original
+    resource from which the seekable stream was manufactured.
+
+php_stream_read
+^^^^^^^^^^^^^^^
+
+Read a number of bytes from a stream into a buffer::
+
+    size_t php_stream_read(php_stream *stream, char *buf, size_t count)
+
+``php_stream_read`` reads up to ``count``
+bytes of data from ``stream`` and copies them into the
+buffer ``buf``.
+
+``php_stream_read`` returns the number of bytes that were
+read successfully.  There is no distinction between a failed read or an end-of-file
+condition – use ``php_stream_eof`` to test for an ``EOF``.
+
+The internal position of the stream is advanced by the number of bytes that were
+read, so that subsequent reads will continue reading from that point.
+
+If less than ``count`` bytes are available to be read, this
+call will block (or wait) until the required number are available, depending on the
+blocking status of the stream.  By default, a stream is opened in blocking mode.
+When reading from regular files, the blocking mode will not usually make any
+difference: when the stream reaches the ``EOF``
+``php_stream_read`` will return a value less than
+``count``, and 0 on subsequent reads.
+
+php_stream_write
+^^^^^^^^^^^^^^^^
+
+Write a number of bytes from a buffer to a stream::
+
+    size_t php_stream_write(php_stream *stream, const char *buf, size_t count)
+
+``php_stream_write`` writes ``count``
+bytes of data from ``buf`` into ``stream``.
+
+``php_stream_write`` returns the number of bytes that were
+written successfully.  If there was an error, the number of bytes written will be
+less than ``count``.
+
+The internal position of the stream is advanced by the number of bytes that were
+written, so that subsequent writes will continue writing from that point.
+
+php_stream_eof
+^^^^^^^^^^^^^^
+
+Check for an end-of-file condition on a stream::
+
+    int php_stream_eof(php_stream *stream)
+
+``php_stream_eof`` checks for an end-of-file condition
+on ``stream``.
+
+``php_stream_eof`` returns the 1 to indicate
+``EOF``, 0 if there is no ``EOF`` and -1 to indicate an error.
+
+php_stream_getc
+^^^^^^^^^^^^^^^
+
+Read a single byte from a stream::
+
+    int php_stream_getc(php_stream *stream)
+
+``php_stream_getc`` reads a single character from
+``stream`` and returns it as an unsigned char cast
+as an int, or ``EOF`` if the end-of-file is reached, or an error occurred.
+
+``php_stream_getc`` may block in the same way as
+``php_stream_read`` blocks.
+
+The internal position of the stream is advanced by 1 if successful.
+
+php_stream_gets
+^^^^^^^^^^^^^^^
+
+Read a line of data from a stream into a buffer::
+
+    char *php_stream_gets(php_stream *stream, char *buf, size_t maxlen)
+
+``php_stream_gets`` reads up to ``count``-1
+bytes of data from ``stream`` and copies them into the
+buffer ``buf``.  Reading stops after an ``EOF``
+or a newline.  If a newline is read, it is stored in ``buf`` as part of
+the returned data.  A NUL terminating character is stored as the last character
+in the buffer.
+
+``php_stream_read`` returns ``buf``
+when successful or NULL otherwise.
+
+The internal position of the stream is advanced by the number of bytes that were
+read, so that subsequent reads will continue reading from that point.
+
+This function may block in the same way as ``php_stream_read``.
+
+php_stream_close
+^^^^^^^^^^^^^^^^
+
+Close a stream::
+
+    int php_stream_close(php_stream *stream)
+
+``php_stream_close`` safely closes ``stream``
+and releases the resources associated with it.  After ``stream``
+has been closed, it's value is undefined and should not be used.
+
+``php_stream_close`` returns 0 if the stream was closed or
+``EOF``  to indicate an error.  Regardless of the success of the call,
+``stream`` is undefined and should not be used after a call to
+this function.
+
+php_stream_flush
+^^^^^^^^^^^^^^^^
+
+Flush stream buffers to storage::
+
+    int php_stream_flush(php_stream *stream)
+
+``php_stream_flush`` causes any data held in
+write buffers in ``stream`` to be committed to the
+underlying storage.
+
+``php_stream_flush`` returns 0 if the buffers were flushed,
+or if the buffers did not need to be flushed, but returns ``EOF`` 
+to indicate an error.
+
+php_stream_seek
+^^^^^^^^^^^^^^^
+
+Reposition a stream::
+
+    int php_stream_seek(php_stream *stream, off_t offset, int whence)
+
+``php_stream_seek`` repositions the internal
+position of ``stream``.
+The new position is determined by adding the ``offset``
+to the position indicated by ``whence``.
+If ``whence`` is set to ``SEEK_SET``,
+``SEEK_CUR`` or ``SEEK_END`` the offset
+is relative to the start of the stream, the current position or the end of the stream, respectively.
+
+``php_stream_seek`` returns 0 on success, but -1 if there was an error.
+
+.. note:: 
+    Not all streams support seeking, although the streams API will emulate a seek if
+    ``whence`` is set to ``SEEK_CUR``
+    and ``offset`` is positive, by calling ``php_stream_read``
+    to read (and discard) ``offset`` bytes.
+
+    The emulation is only applied when the underlying stream implementation does not
+    support seeking.  If the stream is (for example) a file based stream that is wrapping
+    a non-seekable pipe, the streams api will not apply emulation because the file based
+    stream implements a seek operation; the seek will fail and an error result will be
+    returned to the caller.
+
+php_stream_tell
+^^^^^^^^^^^^^^^
+
+Determine the position of a stream::
+
+    off_t php_stream_tell(php_stream *stream)
+
+``php_stream_tell`` returns the internal position of
+``stream``, relative to the start of the stream.
+If there is an error, -1 is returned.
+
+php_stream_copy_to_stream
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Copy data from one stream to another::
+
+    size_t php_stream_copy_to_stream(php_stream *src, php_stream *dest, size_t maxlen)
+
+``php_stream_copy_to_stream`` attempts to read up to ``maxlen``
+bytes of data from ``src`` and write them to ``dest``,
+and returns the number of bytes that were successfully copied.
+
+If you want to copy all remaining data from the ``src`` stream, pass the
+constant ``PHP_STREAM_COPY_ALL`` as the value of ``maxlen``.
+
+.. note::
+    This function will attempt to copy the data in the most efficient manner, using memory mapped
+    files when possible.
+
+php_stream_copy_to_mem
+^^^^^^^^^^^^^^^^^^^^^^
+
+Copy data from stream and into an allocated buffer::
+
+    size_t php_stream_copy_to_mem(php_stream *src, char **buf, size_t maxlen, int persistent)
+
+``php_stream_copy_to_mem`` allocates a buffer ``maxlen``+1
+bytes in length using ``pemalloc`` (passing ``persistent``).
+It then reads ``maxlen`` bytes from ``src`` and stores
+them in the allocated buffer.
+
+The allocated buffer is returned in ``buf``, and the number of bytes successfully
+read.  You, the caller, are responsible for freeing the buffer by passing it and ``persistent``
+to ``pefree``.
+
+If you want to copy all remaining data from the ``src`` stream, pass the
+constant ``PHP_STREAM_COPY_ALL`` as the value of ``maxlen``.
+
+.. note::
+    This function will attempt to copy the data in the most efficient manner, using memory mapped
+    files when possible.
+
+php_stream_make_seekable
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Convert a stream into a stream is seekable::
+
+    int php_stream_make_seekable(php_stream *origstream, php_stream **newstream, int flags)
+
+``php_stream_make_seekable`` checks if ``origstream`` is
+seekable.   If it is not, it will copy the data into a new temporary stream.
+If successful, ``newstream`` is always set to the stream that is valid to use, even if the original
+stream was seekable.
+
+``flags`` allows you to specify your preference for the seekable stream that is
+returned: use ``PHP_STREAM_NO_PREFERENCE`` to use the default seekable stream
+(which uses a dynamically expanding memory buffer, but switches to temporary file backed storage
+when the stream size becomes large), or use ``PHP_STREAM_PREFER_STDIO`` to
+use "regular" temporary file backed storage.
+
+``php_stream_make_seekable`` return values
+
+``PHP_STREAM_UNCHANGED``
+    Original stream was seekable anyway. ``newstream`` is set to the value
+    of ``origstream``.
+
+``PHP_STREAM_RELEASED``
+    Original stream was not seekable and has been released. ``newstream`` is set to the
+    new seekable stream.  You should not access ``origstream`` anymore.
+
+``PHP_STREAM_FAILED``
+    An error occurred while attempting conversion. ``newstream`` is set to NULL;
+    ``origstream`` is still valid.
+
+``PHP_STREAM_CRITICAL``
+    An error occurred while attempting conversion that has left ``origstream`` in
+    an indeterminate state. ``newstream`` is set to NULL and it is highly recommended
+    that you close ``origstream``.
+
+.. note::
+    If you need to seek and write to the stream, it does not make sense to use this function, because the stream
+    it returns is not guaranteed to be bound to the same resource as the original stream.
+
+.. note::
+    If you only need to seek forwards, there is no need to call this function, as the streams API will emulate
+    forward seeks when the whence parameter is ``SEEK_CUR``.
+
+.. note::
+    If ``origstream`` is network based, this function will block until the whole contents
+    have been downloaded.
+
+.. note::
+    NEVER call this function with an ``origstream`` that is reference by a file pointer
+    in a PHP script!  This function may cause the underlying stream to be closed which could cause a crash
+    when the script next accesses the file pointer!
+
+.. note::
+    In many cases, this function can only succeed when ``origstream`` is a newly opened
+    stream with no data buffered in the stream layer.  For that reason, and because this function is complicated to
+    use correctly, it is recommended that you use ``php_stream_open_wrapper`` and pass in
+    ``PHP_STREAM_MUST_SEEK`` in your options instead of calling this function directly.
+
+php_stream_cast
+^^^^^^^^^^^^^^^
+
+Convert a stream into another form, such as a FILE* or socket::
+
+    int php_stream_cast(php_stream *stream, int castas, void **ret, intflags)
+
+``php_stream_cast`` attempts to convert ``stream`` into
+a resource indicated by ``castas``.
+If ``ret`` is NULL, the stream is queried to find out if such a conversion is
+possible, without actually performing the conversion (however, some internal stream state *might*
+be changed in this case).
+If ``flags`` is set to ``REPORT_ERRORS``, an error
+message will be displayed is there is an error during conversion.
+
+.. note::
+    This function returns ``SUCCESS`` for success or ``FAILURE``
+    for failure.  Be warned that you must explicitly compare the return value with ``SUCCESS``
+    or ``FAILURE`` because of the underlying values of those constants. A simple
+    boolean expression will not be interpreted as you intended.
+
+Resource types for ``castas``
+
+``PHP_STREAM_AS_STDIO``
+    Requests an ANSI FILE* that represents the stream
+
+``PHP_STREAM_AS_FD``
+    Requests a POSIX file descriptor that represents the stream
+
+``PHP_STREAM_AS_SOCKETD``
+    Requests a network socket descriptor that represents the stream
+
+In addition to the basic resource types above, the conversion process can be altered by using the
+following flags by using the OR operator to combine the resource type with one or more of the
+following values:
+
+Resource types for ``castas``
+
+``PHP_STREAM_CAST_TRY_HARD``
+    Tries as hard as possible, at the expense of additional resources, to ensure that the conversion succeeds
+
+``PHP_STREAM_CAST_RELEASE``
+    Informs the streams API that some other code (possibly a third party library) will be responsible for closing the
+    underlying handle/resource.  This causes the ``stream`` to be closed in such a way the underlying
+    handle is preserved and returned in ``ret``.  If this function succeeds, ``stream``
+    should be considered closed and should no longer be used.
+
+.. note::
+    If your system supports ``fopencookie`` (systems using glibc 2 or later), the streams API
+    will always be able to synthesize an ANSI FILE* pointer over any stream.
+    While this is tremendously useful for passing any PHP stream to any third-party libraries, such behaviour is not
+    portable.  You are requested to consider the portability implications before distributing you extension.
+    If the fopencookie synthesis is not desirable, you should query the stream to see if it naturally supports FILE*
+    by using ``php_stream_is``
+
+.. note::
+    If you ask a socket based stream for a FILE*, the streams API will use ``fdopen`` to
+    create it for you.  Be warned that doing so may cause data that was buffered in the streams layer to be
+    lost if you intermix streams API calls with ANSI stdio calls.
+
+See also ``php_stream_is`` and ``php_stream_can_cast``.
+ 
+php_stream_can_cast
+^^^^^^^^^^^^^^^^^^^
+
+Determines if a stream can be converted into another form, such as a FILE* or socket::
+
+    int php_stream_can_cast(php_stream *stream, int castas)
+
+This function is equivalent to calling ``php_stream_cast`` with ``ret``
+set to NULL and ``flags`` set to 0.
+It returns ``SUCCESS`` if the stream can be converted into the form requested, or
+``FAILURE`` if the conversion cannot be performed.
+
+.. note::
+    Although this function will not perform the conversion, some internal stream state *might* be
+    changed by this call.
+
+.. note::
+    You must explicitly compare the return value of this function with one of the constants, as described
+    in ``php_stream_cast``.
+
+See also ``php_stream_cast`` and ``php_stream_is``.
+
+php_stream_is_persistent
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Determines if a stream is a persistent stream::
+
+    int php_stream_is_persistent(php_stream *stream)
+
+``php_stream_is_persistent`` returns 1 if the stream is a persistent stream,
+0 otherwise.
+
+php_stream_is
+^^^^^^^^^^^^^
+
+Determines if a stream is of a particular type::
+
+    int php_stream_is(php_stream *stream, int istype)
+
+``php_stream_is`` returns 1 if ``stream`` is of
+the type specified by ``istype``, or 0 otherwise.
+
+Values for ``istype``
+
+``PHP_STREAM_IS_STDIO``
+    The stream is implemented using the stdio implementation
+
+``PHP_STREAM_IS_SOCKET``
+    The stream is implemented using the network socket implementation
+
+``PHP_STREAM_IS_USERSPACE``
+    The stream is implemented using the userspace object implementation
+
+``PHP_STREAM_IS_MEMORY``
+    The stream is implemented using the grow-on-demand memory stream implementation
+
+.. note::
+    The PHP_STREAM_IS_XXX "constants" are actually defined as pointers to the underlying
+    stream operations structure.  If your extension (or some other extension) defines additional
+    streams, it should also declare a PHP_STREAM_IS_XXX constant in it's header file that you
+    can use as the basis of this comparison.
+
+.. note::
+    This function is implemented as a simple (and fast) pointer comparison, and does not change
+    the stream state in any way.
+
+See also ``php_stream_cast`` and ``php_stream_can_cast``.
+
+php_stream_passthru
+^^^^^^^^^^^^^^^^^^^
+
+Outputs all remaining data from a stream::
+
+    size_t php_stream_passthru(php_stream *stream)
+
+``php_stream_passthru`` outputs all remaining data from ``stream``
+to the active output buffer and returns the number of bytes output.
+If buffering is disabled, the data is written straight to the output, which is the browser making the
+request in the case of PHP on a web server, or stdout for CLI based PHP.
+This function will use memory mapped files if possible to help improve performance.
+
+php_register_url_stream_wrapper
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Registers a wrapper with the Streams API::
+
+    int php_register_url_stream_wrapper(char *protocol, php_stream_wrapper *wrapper, TSRMLS_DC)
+
+``php_register_url_stream_wrapper`` registers ``wrapper``
+as the handler for the protocol specified by ``protocol``.
+
+.. note::
+    If you call this function from a loadable module, you *MUST* call ``php_unregister_url_stream_wrapper``
+    in your module shutdown function, otherwise PHP will crash.
+
+php_unregister_url_stream_wrapper
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Unregisters a wrapper from the Streams API::
+
+    int php_unregister_url_stream_wrapper(char *protocol, TSRMLS_DC)
+
+``php_unregister_url_stream_wrapper`` unregisters the wrapper
+associated with ``protocol``.
+
+php_stream_open_wrapper_ex
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Opens a stream on a file or URL, specifying context::
+
+    php_stream *php_stream_open_wrapper_ex(char *path, char *mode, int options, char **opened, php_stream_context *context)
+
+``php_stream_open_wrapper_ex`` is exactly like
+``php_stream_open_wrapper``, but allows you to specify a
+php_stream_context object using ``context``.
+To find out more about stream contexts,
+see `Stream Contexts <https://www.php.net/manual/en/stream.contexts.php>`_.
+
+php_stream_open_wrapper_as_file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Opens a stream on a file or URL, and converts to a FILE*::
+
+    FILE * php_stream_open_wrapper_as_file(char *path, char *mode, int options, char **opened)
+
+``php_stream_open_wrapper_as_file`` is exactly like
+``php_stream_open_wrapper``, but converts the stream
+into an ANSI stdio FILE* and returns that instead of the stream.
+This is a convenient shortcut for extensions that pass FILE* to third-party libraries.
+
+php_stream_filter_register_factory
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Registers a filter factory with the Streams API::
+
+    int php_stream_filter_register_factory(const char *filterpattern, php_stream_filter_factory *factory)
+
+Use this function to register a filter factory with the name given by
+``filterpattern``.  ``filterpattern``
+can be either a normal string name (i.e. ``myfilter``) or
+a global pattern (i.e. ``myfilterclass.*``) to allow a single
+filter to perform different operations depending on the exact name of the filter
+invoked (i.e. ``myfilterclass.foo``, ``myfilterclass.bar``,
+etc...)
+
+.. note::
+    Filters registered by a loadable extension must be certain to call
+    php_stream_filter_unregister_factory() during MSHUTDOWN.
+
+php_stream_filter_unregister_factory
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Deregisters a filter factory with the Streams API::
+
+    int php_stream_filter_unregister_factory(const char *filterpattern)
+
+Deregisters the ``filterfactory`` specified by the
+``filterpattern`` making it no longer available for use.
+
+.. note::
+    Filters registered by a loadable extension must be certain to call
+    php_stream_filter_unregister_factory() during MSHUTDOWN.

--- a/Book/php7/internal_types/streams/constants.rst
+++ b/Book/php7/internal_types/streams/constants.rst
@@ -1,0 +1,70 @@
+.. _streams_open_options:
+
+Streams open options
+--------------------
+  
+These constants affect the operation of stream factory functions.
+
+``IGNORE_PATH``
+    This is the default option for streams; it requests that the include_path is
+    not to be searched for the requested file.
+
+``USE_PATH``
+    Requests that the include_path is to be searched for the requested file.
+
+``IGNORE_URL``
+    Requests that registered URL wrappers are to be ignored when opening the
+    stream.  Other non-URL wrappers will be taken into consideration when
+    decoding the path.  There is no opposite form for this flag; the streams
+    API will use all registered wrappers by default.
+
+``IGNORE_URL_WIN``
+    On Windows systems, this is equivalent to IGNORE_URL.
+    On all other systems, this flag has no effect.
+
+``ENFORCE_SAFE_MODE``
+    Requests that the underlying stream implementation perform safe_mode
+    checks on the file before opening the file.  Omitting this flag will skip
+    safe_mode checks and allow opening of any file that the PHP process
+    has rights to access.
+
+``REPORT_ERRORS``
+    If this flag is set, and there was an error during the opening of the file
+    or URL, the streams API will call the php_error function for you.  This
+    is useful because the path may contain username/password information
+    that should not be displayed in the browser output (it would be a
+    security risk to do so).  When the streams API raises the error, it first
+    strips username/password information from the path, making the error
+    message safe to display in the browser.
+
+``STREAM_MUST_SEEK``
+    This flag is useful when your extension really must be able to randomly
+    seek around in a stream.  Some streams may not be seekable in their
+    native form, so this flag asks the streams API to check to see if the
+    stream does support seeking.  If it does not, it will copy the stream
+    into temporary storage (which may be a temporary file or a memory
+    stream) which does support seeking.
+    Please note that this flag is not useful when you want to seek the
+    stream and write to it, because the stream you are accessing might
+    not be bound to the actual resource you requested.
+
+.. note:: If the requested resource is network based, this flag will cause the
+          opener to block until the whole contents have been downloaded.
+
+``STREAM_WILL_CAST``
+    If your extension is using a third-party library that expects a FILE* or
+    file descriptor, you can use this flag to request the streams API to
+    open the resource but avoid buffering.  You can then use
+    ``php_stream_cast`` to retrieve the FILE* or
+    file descriptor that the library requires.
+
+    The is particularly useful when accessing HTTP URLs where the start
+    of the actual stream data is found after an indeterminate offset into
+    the stream.
+
+    Since this option disables buffering at the streams API level, you
+    may experience lower performance when using streams functions
+    on the stream; this is deemed acceptable because you have told
+    streams that you will be using the functions to match the underlying
+    stream implementation.
+    Only use this option when you are sure you need it.

--- a/Book/php7/internal_types/streams/dir.rst
+++ b/Book/php7/internal_types/streams/dir.rst
@@ -1,0 +1,53 @@
+Streams Dir API Reference
+-------------------------
+
+The functions listed in this section work on local files, as well as remote files
+(provided that the wrapper supports this functionality!).
+
+php_stream_opendir
+^^^^^^^^^^^^^^^^^^
+
+Open a directory for file enumeration::
+
+    php_stream * php_stream_opendir(char *path, php_stream_context *context)
+
+``php_stream_opendir`` returns a stream that can be used to list the
+files that are contained in the directory specified by ``path``.
+This function is functionally equivalent to POSIX ``opendir``.
+Although this function returns a php_stream object, it is not recommended to
+try to use the functions from the common API on these streams.
+
+php_stream_readdir
+^^^^^^^^^^^^^^^^^^
+
+Fetch the next directory entry from an opened dir::
+
+    php_stream_dirent *php_stream_readdir(php_stream *dirstream, php_stream_dirent *ent)
+
+``php_stream_readdir`` reads the next directory entry
+from ``dirstream`` and stores it into ``ent``.
+If the function succeeds, the return value is ``ent``.
+If the function fails, the return value is NULL.
+See :ref:`php_stream_dirent` for more
+details about the information returned for each directory entry.
+
+php_stream_rewinddir
+^^^^^^^^^^^^^^^^^^^^
+
+Rewind a directory stream to the first entry::
+
+    int php_stream_rewinddir(php_stream *dirstream)
+
+``php_stream_rewinddir`` rewinds a directory stream to the first entry.
+Returns 0 on success, but -1 on failure.
+
+php_stream_closedir
+^^^^^^^^^^^^^^^^^^^
+
+Close a directory stream and release resources::
+
+    int php_stream_closedir(php_stream *dirstream)
+
+``php_stream_closedir`` closes a directory stream and releases
+resources associated with it.
+Returns 0 on success, but -1 on failure.

--- a/Book/php7/internal_types/streams/file.rst
+++ b/Book/php7/internal_types/streams/file.rst
@@ -1,0 +1,41 @@
+Streams File API Reference
+--------------------------
+
+php_stream_fopen_from_file
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Convert an ANSI FILE* into a stream::
+
+    php_stream *php_stream_fopen_from_file(FILE *file, char *mode)
+
+``php_stream_fopen_from_file`` returns a stream based on the
+``file``. ``mode`` must be the same
+as the mode used to open ``file``, otherwise strange errors
+may occur when trying to write when the mode of the stream is different from the mode
+on the file.
+
+php_stream_fopen_tmpfile
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Open a FILE* with tmpfile() and convert into a stream::
+
+    php_stream *php_stream_fopen_tmpfile(void)
+
+``php_stream_fopen_tmpfile`` returns a stream based on a
+temporary file opened with a mode of "w+b".  The temporary file will be deleted
+automatically when the stream is closed or the process terminates.
+
+php_stream_fopen_temporary_file
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Generate a temporary file name and open a stream on it::
+
+    php_stream *php_stream_fopen_temporary_file(const char *dir, const char *pfx, char **opened)
+
+``php_stream_fopen_temporary_file`` generates a temporary file name
+in the directory specified by ``dir`` and with a prefix of ``pfx``.
+The generated file name is returns in the ``opened`` parameter, which you
+are responsible for cleaning up using ``efree``.
+A stream is opened on that generated filename in "w+b" mode.
+The file is NOT automatically deleted; you are responsible for unlinking or moving the file when you have
+finished with it.

--- a/Book/php7/internal_types/streams/socket.rst
+++ b/Book/php7/internal_types/streams/socket.rst
@@ -1,0 +1,73 @@
+Streams Socket API Reference
+----------------------------
+
+php_stream_sock_open_from_socket
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Convert a socket descriptor into a stream::
+
+    php_stream *php_stream_sock_open_from_socket(int socket, int persistent)
+
+``php_stream_sock_open_from_socket`` returns a stream based on the
+``socket``. ``persistent`` is a flag that
+controls whether the stream is opened as a persistent stream.  Generally speaking, this parameter
+will usually be 0.
+
+php_stream_sock_open_host
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Open a connection to a host and return a stream::
+
+    php_stream *php_stream_sock_open_host(const char *host, unsigned short port, int socktype,
+                                          struct timeval *timeout, int persistent)
+
+``php_stream_sock_open_host`` establishes a connect to the specified
+``host`` and ``port``. ``socktype``
+specifies the connection semantics that should apply to the connection. Values for
+``socktype`` are system dependent, but will usually include (at a minimum)
+``SOCK_STREAM`` for sequenced, reliable, two-way connection based streams (TCP),
+or ``SOCK_DGRAM`` for connectionless, unreliable messages of a fixed maximum
+length (UDP).
+
+``persistent`` is a flag the controls whether the stream is opened as a persistent
+stream. Generally speaking, this parameter will usually be 0.
+
+If not NULL, ``timeout`` specifies a maximum time to allow for the connection to be made.
+If the connection attempt takes longer than the timeout value, the connection attempt is aborted and
+NULL is returned to indicate that the stream could not be opened.
+
+.. note::
+    The timeout value does not include the time taken to perform a DNS lookup. The reason for this is
+    because there is no portable way to implement a non-blocking DNS lookup.
+
+    The timeout only applies to the connection phase; if you need to set timeouts for subsequent read
+    or write operations, you should use ``php_stream_sock_set_timeout`` to configure
+    the timeout duration for your stream once it has been opened.
+
+The streams API places no restrictions on the values you use for ``socktype``,
+but encourages you to consider the portability of values you choose before you release your
+extension.
+
+php_stream_sock_open_unix
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Open a Unix domain socket and convert into a stream::
+
+    php_stream *php_stream_sock_open_unix(const char *path, int pathlen, int persistent, struct timeval *timeout)
+
+``php_stream_sock_open_unix`` attempts to open the Unix domain socket
+specified by ``path``.  ``pathlen`` specifies the
+length of ``path``.
+If ``timeout`` is not NULL, it specifies a timeout period for the connection attempt.
+``persistent`` indicates if the stream should be opened as a persistent
+stream. Generally speaking, this parameter will usually be 0.
+
+.. note::
+    This function will not work under Windows, which does not implement Unix domain sockets.
+    A possible exception to this rule is if your PHP binary was built using cygwin.  You are encouraged
+    to consider this aspect of the portability of your extension before it's release.
+
+.. note::
+    This function treats ``path`` in a binary safe manner, suitable for
+    use on systems with an abstract namespace (such as Linux), where the first character
+    of path is a NUL character.

--- a/Book/php7/internal_types/streams/structs.rst
+++ b/Book/php7/internal_types/streams/structs.rst
@@ -1,0 +1,130 @@
+Streams Structures
+------------------
+
+.. _php_stream_statbuf:
+
+php_stream_statbuf
+^^^^^^^^^^^^^^^^^^
+
+Holds information about a file or URL::
+
+    typedef struct _php_stream_statbuf {
+        struct stat sb;
+    } php_stream_statbuf;
+
+``sb`` is a regular, system defined, struct stat.
+
+.. _php_stream_dirent:
+
+php_stream_dirent
+^^^^^^^^^^^^^^^^^
+
+Holds information about a single file during dir scanning::
+
+    typedef struct _php_stream_dirent {
+        char d_name[MAXPATHLEN]
+    } php_stream_dirent;
+
+``d_name`` holds the name of the file, relative to the directory
+being scanned.
+
+php_stream_ops
+^^^^^^^^^^^^^^
+
+Holds member functions for a stream implementation::
+
+    typedef struct _php_stream_ops {
+        /* all streams MUST implement these operations */
+        size_t (*write)(php_stream *stream, const char *buf, size_t count TSRMLS_DC);
+        size_t (*read)(php_stream *stream, char *buf, size_t count TSRMLS_DC);
+        int (*close)(php_stream *stream, int close_handle TSRMLS_DC);
+        int (*flush)(php_stream *stream TSRMLS_DC);
+        
+        const char *label; /* name describing this class of stream */
+        
+        /* these operations are optional, and may be set to NULL if the stream does not
+         * support a particular operation */
+        int (*seek)(php_stream *stream, off_t offset, int whence TSRMLS_DC);
+        char *(*gets)(php_stream *stream, char *buf, size_t size TSRMLS_DC);
+        int (*cast)(php_stream *stream, int castas, void **ret TSRMLS_DC);
+        int (*stat)(php_stream *stream, php_stream_statbuf *ssb TSRMLS_DC);
+    } php_stream_ops;
+
+php_stream_wrapper
+^^^^^^^^^^^^^^^^^^
+
+Holds wrapper properties and pointer to operations::
+
+    typedef struct _php_stream_wrapper {
+        php_stream_wrapper_ops *wops;   /* operations the wrapper can perform */
+        void *abstract;                 /* context for the wrapper */
+        int is_url;                     /* so that PG(allow_url_fopen) can be respected */
+
+        /* support for wrappers to return (multiple) error messages to the stream opener */
+        int err_count;
+        char **err_stack;
+    } php_stream_wrapper;
+
+php_stream_wrapper_ops
+^^^^^^^^^^^^^^^^^^^^^^
+
+Holds member functions for a stream wrapper implementation::
+
+    typedef struct _php_stream_wrapper_ops {
+        /* open/create a wrapped stream */
+        php_stream *(*stream_opener)(php_stream_wrapper *wrapper, char *filename, char *mode,
+                int options, char **opened_path, php_stream_context *context STREAMS_DC TSRMLS_DC);
+        /* close/destroy a wrapped stream */
+        int (*stream_closer)(php_stream_wrapper *wrapper, php_stream *stream TSRMLS_DC);
+        /* stat a wrapped stream */
+        int (*stream_stat)(php_stream_wrapper *wrapper, php_stream *stream, php_stream_statbuf *ssb TSRMLS_DC);
+        /* stat a URL */
+        int (*url_stat)(php_stream_wrapper *wrapper, char *url, php_stream_statbuf *ssb TSRMLS_DC);
+        /* open a "directory" stream */
+        php_stream *(*dir_opener)(php_stream_wrapper *wrapper, char *filename, char *mode,
+                int options, char **opened_path, php_stream_context *context STREAMS_DC TSRMLS_DC);
+
+        const char *label;
+
+        /* Delete/Unlink a file */
+        int (*unlink)(php_stream_wrapper *wrapper, char *url, int options, php_stream_context *context TSRMLS_DC);
+    } php_stream_wrapper_ops;
+
+php_stream_filter
+^^^^^^^^^^^^^^^^^
+
+Holds filter properties and pointer to operations::
+
+    typedef struct _php_stream_filter {
+        php_stream_filter_ops *fops;
+        void *abstract; /* for use by filter implementation */
+        php_stream_filter *next;
+        php_stream_filter *prev;
+        int is_persistent;
+
+        /* link into stream and chain */
+        php_stream_filter_chain *chain;
+
+        /* buffered buckets */
+        php_stream_bucket_brigade buffer;
+    } php_stream_filter;
+
+php_stream_filter_ops
+^^^^^^^^^^^^^^^^^^^^^
+
+Holds member functions for a stream filter implementation::
+
+    typedef struct _php_stream_filter_ops {
+        php_stream_filter_status_t (*filter)(
+            php_stream *stream,
+            php_stream_filter *thisfilter,
+            php_stream_bucket_brigade *buckets_in,
+            php_stream_bucket_brigade *buckets_out,
+            size_t *bytes_consumed,
+            int flags
+            TSRMLS_DC);
+
+        void (*dtor)(php_stream_filter *thisfilter TSRMLS_DC);
+
+        const char *label;
+    } php_stream_filter_ops;


### PR DESCRIPTION
Almost literally converted from the PHP manual[1].

[1] <https://www.php.net/manual/en/internals2.ze1.streams.php>

---

I have doubts that this information is useful here, even if updated. Might make more sense to add some more comments to php_streams.h.