### PR TITLE
Remove old git.php.net references

### DIFF
--- a/Book/php5/build_system/building_php.rst
+++ b/Book/php5/build_system/building_php.rst
@@ -48,8 +48,7 @@ Obtaining the source code
 -------------------------
 
 Before you can build PHP you first need to obtain its source code. There are two ways to do this: You can either
-download an archive from `PHP's download page`_ or clone the git repository from `git.php.net`_ (or the mirror on
-`Github`_).
+download an archive from `PHP's download page`_ or clone the git repository from `Github`_.
 
 The build process is slightly different for both cases: The git repository doesn't bundle a ``configure`` script, so
 you'll need to generate it using the ``buildconf`` script, which makes use of autoconf. Furthermore the git repository
@@ -61,7 +60,7 @@ submit patches or pull requests for PHP.
 
 To clone the repository, run the following commands in your shell::
 
-    ~> git clone http://git.php.net/repository/php-src.git
+    ~> git clone https://github.com/php/php-src.git
     ~> cd php-src
     # by default you will be on the master branch, which is the current
     # development version. You can check out a stable branch instead:

--- a/Book/php7/build_system/building_php.rst
+++ b/Book/php7/build_system/building_php.rst
@@ -48,8 +48,7 @@ Obtaining the source code
 -------------------------
 
 Before you can build PHP you first need to obtain its source code. There are two ways to do this: You can either
-download an archive from `PHP's download page`_ or clone the git repository from `git.php.net`_ (or the mirror on
-`Github`_).
+download an archive from `PHP's download page`_ or clone the git repository from `Github`_.
 
 The build process is slightly different for both cases: The git repository doesn't bundle a ``configure`` script, so
 you'll need to generate it using the ``buildconf`` script, which makes use of autoconf. Furthermore the git repository
@@ -61,7 +60,7 @@ submit patches or pull requests for PHP.
 
 To clone the repository, run the following commands in your shell::
 
-    ~> git clone http://git.php.net/repository/php-src.git
+    ~> git clone https://github.com/php/php-src.git
     ~> cd php-src
     # by default you will be on the master branch, which is the current
     # development version. You can check out a stable branch instead:


### PR DESCRIPTION
Replace old references to git.php.net for github.com links