### PR TITLE
Install Sphinx before building release (GHA)

### DIFF
--- a/.github/workflows/publish-to-github-pages.yml
+++ b/.github/workflows/publish-to-github-pages.yml
@@ -12,6 +12,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: Setup Python 3.x
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Install Sphinx
+        run: pip install -U Sphinx
+
+      - name: Setup PHP 8.1
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          coverage: none
+          extensions: none
+          tools: none
+
       - name: Generate HTML release
         run: ./build_release_html.sh
 


### PR DESCRIPTION
This PR fixes the build/publish automation introduced by #109.

Action Steps:

1. Installs Python 3.x;
2. Installs Sphinx;
3. Installs PHP 8.1;
4. Executes the release script.