### PR TITLE
fix: add missing PHP_FE_END in example

### DIFF
--- a/Book/php7/extensions_design/php_functions.rst
+++ b/Book/php7/extensions_design/php_functions.rst
@@ -85,6 +85,7 @@ You'll pass to the function vector a declared vector of functions. Let's see tog
     static const zend_function_entry pib_functions[] =
     {
         PHP_FE(fahrenheit_to_celsius, NULL)
+        PHP_FE_END
     };
 
     zend_module_entry pib_module_entry = {


### PR DESCRIPTION
Hi :wave: :slightly_smiling_face: 

The first example to register a C function lacks a `PHP_FE_END` to properly finish the declaration of the `zend_function_entry`. Without this line, I reached a _Segmentation Fault_ ...

Thank you very much for this very important documentation about Php internals! :bow: 