### PR TITLE
Use first 3 instead of first 4 in INI registration section

### DIFF
--- a/Book/php7/extensions_design/ini_settings.rst
+++ b/Book/php7/extensions_design/ini_settings.rst
@@ -235,7 +235,7 @@ declared. Like this::
     }
 
 We declare a global named ``max_rnd``, of type ``zend_ulong``. Then, we register our *'pib.rnd_max'* INI value using
-``STD_PHP_INI_ENTRY()`` this time. That allows us to pass more parameters to the macro. The first four ones are known,
+``STD_PHP_INI_ENTRY()`` this time. That allows us to pass more parameters to the macro. The first three ones are known,
 we detailed them before in the chapter.
 
 The four last parameters represent the globals bridge. We tell that we want to update ``max_rnd``, in the


### PR DESCRIPTION
As the fourth one is being described in this section.
Moreover, the sentence afterwards talks about the last 4 arguments, to a macro which only takes 7.

(PS: doing stuff via the GitHub online interface is a bit of a mess so the commit title is incorrect)