### PR TITLE
Update buildconf script info

### DIFF
--- a/Book/php7/build_system/building_php.rst
+++ b/Book/php7/build_system/building_php.rst
@@ -140,7 +140,7 @@ The ``./buildconf`` script
 --------------------------
 
 If you are building from the git repository, the first thing you'll have to do is run the ``./buildconf`` script. This
-script does little more than invoking the ``autoconf``.
+script does little more than invoking ``autoconf``.
 
 The main job of this script is to run ``autoconf`` to generate the ``./configure`` script and ``autoheader`` to
 generate the ``main/php_config.h.in`` template. The latter file will be used by configure to generate the final

--- a/Book/php7/build_system/building_php.rst
+++ b/Book/php7/build_system/building_php.rst
@@ -142,7 +142,7 @@ The ``./buildconf`` script
 If you are building from the git repository, the first thing you'll have to do is run the ``./buildconf`` script. This
 script does little more than invoking ``autoconf``.
 
-The main job of this script is to run ``autoconf`` to generate the ``./configure`` script and ``autoheader`` to
+The main job of ``autoconf`` is to generate the ``./configure`` script and ``autoheader`` to
 generate the ``main/php_config.h.in`` template. The latter file will be used by configure to generate the final
 configuration header file ``main/php_config.h``.
 

--- a/Book/php7/build_system/building_php.rst
+++ b/Book/php7/build_system/building_php.rst
@@ -140,9 +140,9 @@ The ``./buildconf`` script
 --------------------------
 
 If you are building from the git repository, the first thing you'll have to do is run the ``./buildconf`` script. This
-script does little more than invoking the ``build/build.mk`` makefile, which in turn calls ``build/build2.mk``.
+script does little more than invoking the ``autoconf``.
 
-The main job of these makefiles is to run ``autoconf`` to generate the ``./configure`` script and ``autoheader`` to
+The main job of this script is to run ``autoconf`` to generate the ``./configure`` script and ``autoheader`` to
 generate the ``main/php_config.h.in`` template. The latter file will be used by configure to generate the final
 configuration header file ``main/php_config.h``.
 


### PR DESCRIPTION
The build/build.mk and build/build2.mk files have been removed to in PHP 7.4 to simplify the build process.