### PR TITLE
Update PHP7 book to be unified for 7 and 8

### DIFF
--- a/Book/_static/style.css
+++ b/Book/_static/style.css
@@ -6,3 +6,34 @@ body {
     min-width: 45em;
     max-width: 60em;
 }
+
+/* Version callout boxes */
+div.versionadded,
+div.versionchanged {
+    border-left: 4px solid;
+    border-radius: 3px;
+    padding: 0.5em 0.75em;
+    margin: 1em 0;
+    font-style: normal;
+}
+
+div.versionadded {
+    background-color: #e8f5e9;
+    border-color: #43a047;
+}
+
+div.versionchanged {
+    background-color: #fff8e1;
+    border-color: #f9a825;
+}
+
+div.versionadded p,
+div.versionchanged p {
+    margin: 0;
+}
+
+div.versionadded span.versionmodified,
+div.versionchanged span.versionmodified {
+    font-weight: bold;
+    font-style: normal;
+}

--- a/Book/index.rst
+++ b/Book/index.rst
@@ -16,6 +16,8 @@ PHP 7 and PHP 8
     php7/memory_management.rst
     php7/zend_engine.rst
     php7/debugging.rst
+    php7/fibers.rst
+    php7/enums.rst
 
 ..
     php7/hashtables.rst

--- a/Book/php7/build_system/building_extensions.rst
+++ b/Book/php7/build_system/building_extensions.rst
@@ -227,3 +227,46 @@ As you can see, this doesn't display any useful information. The reason is that 
 extension and a Zend extension, where the former contains all ini settings, constants and functions. So in this
 particular case you still need to use ``--re``. Other Zend extensions make their information available via ``--rz``
 though.
+
+Stub files and arginfo generation (PHP 8)
+-----------------------------------------
+
+.. versionadded:: PHP 8.0
+
+   PHP 8 introduced **stub files** (``.stub.php``) as the preferred way to declare function,
+   class, and constant signatures for internal extensions. A code generator,
+   ``build/gen_stub.php``, reads these files and produces a ``*_arginfo.h`` C header that is
+   then included in your extension source.
+
+   The ``ext_skel.php`` skeleton generator in PHP 8 creates both a stub file
+   (``myext.stub.php``) and the generated arginfo header (``myext_arginfo.h``) alongside the
+   main extension skeleton.
+
+   To regenerate the arginfo header after editing the stub::
+
+       php /path/to/php-src/build/gen_stub.php ext/myext/myext.stub.php
+
+   The generated header is committed to your repository alongside the stub. Both files should
+   be kept in sync -- ``gen_stub.php`` embeds a hash of the stub file in the header so
+   out-of-date copies are easy to detect.
+
+   As of PHP 8.0, all internal functions are **required** to declare arginfo. Extensions that
+   omit it produce a startup warning. See the dedicated
+   :doc:`Stub files chapter <../extensions_design/stub_files>` for the full details.
+
+C99 and include requirements (PHP 8)
+-------------------------------------
+
+.. versionchanged:: PHP 8.0
+
+   PHP 8 requires a C99 compiler. PHP 8.3 formalised this by removing configure-time feature
+   checks and their ``HAVE_*`` macros.
+
+   PHP 8.4 removed ``main/php_stdint.h``. Replace any inclusion of it with direct includes of
+   the standard headers::
+
+       #include <stdint.h>     /* uint8_t, uint32_t, etc. */
+       #include <inttypes.h>   /* PRId64 and similar format macros */
+
+   Also replace the ``u_char`` typedef (provided by the removed header) with the standard
+   C99 ``uint8_t``.

--- a/Book/php7/build_system/building_php.rst
+++ b/Book/php7/build_system/building_php.rst
@@ -526,3 +526,44 @@ use of the ``./config.nice`` script (which contains your last ``./configure`` ca
 One last cleaning script that PHP provides is ``./vcsclean``. This will only work if you checked out the source code
 from git. It effectively boils down to a call to ``git clean -X -f -d``, which will remove all untracked files and
 directories that are ignored by git. You should use this with care.
+
+PHP 8 build system changes
+--------------------------
+
+.. versionchanged:: PHP 8.0
+
+   * ``--enable-maintainer-zts`` was renamed to ``--enable-zts``. The old flag is no longer
+     accepted. Note that the description of ``--enable-zts`` earlier in this chapter already
+     uses the new name.
+   * ``--disable-inline-optimization`` was removed. Use ``CFLAGS="-O0"`` instead.
+   * ``HAVE_HASH_EXT`` and ``HAVE_PCRE`` compile-time macros were removed because ext/hash and
+     ext/pcre have been non-optional since PHP 7.4. Remove any code guarded by these macros.
+   * The ``PHP_BUILD_SYSTEM`` and ``PHP_BUILD_PROVIDER`` environment variables can be set at
+     configure time to embed build metadata in ``phpinfo()`` output::
+
+         PHP_BUILD_SYSTEM="Ubuntu 22.04" ./configure ...
+
+.. versionchanged:: PHP 8.3
+
+   PHP 8.3 formalised the C99 requirement. The configure-time feature checks that previously
+   set ``HAVE_STDINT_H``, ``HAVE_INTTYPES_H``, and similar macros were removed. Do not test
+   for these macros -- include ``<stdint.h>`` and ``<inttypes.h>`` directly.
+
+   Additionally, many Zend headers that previously included standard library headers
+   transitively had those inclusions cleaned up. Extensions that relied on implicit includes
+   may need to add explicit ``#include`` directives.
+
+   A custom version suffix can now be embedded at configure time::
+
+       ./configure PHP_EXTRA_VERSION="-acme"
+
+.. versionchanged:: PHP 8.4
+
+   Several extensions and their configure options were removed: ``--with-imap``,
+   ``--with-pdo-oci``, ``--with-pspell``, ``--with-zlib-dir``, ``--with-kerberos``,
+   ``--with-openssl-dir``.
+
+   Two new ``php-config`` options were added::
+
+       php-config --lib-dir      # library directory for the embed SAPI
+       php-config --lib-embed    # full path to the embed SAPI static library

--- a/Book/php7/enums.rst
+++ b/Book/php7/enums.rst
@@ -1,0 +1,221 @@
+Enums
+=====
+
+.. versionadded:: PHP 8.1
+
+   Enums were introduced in PHP 8.1 and are not available in PHP 7.
+
+PHP 8.1 introduced enums as a first-class language construct. Enums represent a fixed set of values and
+provide type safety that constants cannot. PHP supports two kinds of enums:
+
+* **Pure (unit) enums** -- cases have no associated value; they are identified solely by their name.
+* **Backed enums** -- each case has an associated scalar value (``int`` or ``string``).
+
+This chapter explains how enums are represented in the engine, how they compare to regular classes
+internally, and how to define and use internal enums from C extension code.
+
+Overview
+--------
+
+Enums are implemented on top of the existing class/object system. There is no separate ``zend_enum``
+struct. Instead, enums are ``zend_class_entry`` instances with the ``ZEND_ACC_ENUM`` flag set. Each enum
+case is stored as a class constant of a special kind (``ZEND_CLASS_CONST_IS_CASE``), whose value is a
+singleton ``zend_object``.
+
+The key implications are:
+
+* Enum case objects can be stored in zvals like any other object.
+* You can use ``instanceof`` to check if a value is of a given enum type.
+* All the standard object handler infrastructure applies.
+* Enum case objects are singletons: two references to the same case are always ``===``.
+
+Enum class entry flags
+-----------------------
+
+Two fields on ``zend_class_entry`` distinguish enums from regular classes:
+
+``ce->ce_flags & ZEND_ACC_ENUM``
+    Set on any enum class.
+
+``ce->enum_backing_type``
+    ``IS_UNDEF`` for pure enums, ``IS_LONG`` for int-backed enums, ``IS_STRING`` for string-backed enums.
+
+Case objects
+-------------
+
+Each enum case is a ``zend_object`` instance. The object stores two properties by numeric index:
+
+* **Slot 0**: The case name as a ``zend_string``. Access with ``zend_enum_fetch_case_name()``.
+* **Slot 1**: The backing value (backed enums only). Access with ``zend_enum_fetch_case_value()``.
+
+These are accessed via ``OBJ_PROP_NUM(zobj, n)``, which indexes the object's inline property table
+by position.
+
+Accessing case properties::
+
+    zend_object *case_obj = /* obtain a case object */;
+
+    /* Name is always available */
+    zval *name_zv = zend_enum_fetch_case_name(case_obj);
+    zend_string *name = Z_STR_P(name_zv);  /* e.g. "Active" */
+
+    /* Value is only available for backed enums */
+    if (case_obj->ce->enum_backing_type != IS_UNDEF) {
+        zval *value_zv = zend_enum_fetch_case_value(case_obj);
+        if (case_obj->ce->enum_backing_type == IS_LONG) {
+            zend_long v = Z_LVAL_P(value_zv);
+        } else {
+            zend_string *v = Z_STR_P(value_zv);
+        }
+    }
+
+The cases table
+----------------
+
+All cases are stored as class constants in ``CE_CONSTANTS_TABLE(ce)``. Each constant has
+``ZEND_CLASS_CONST_IS_CASE`` set in its flags. The constant value is a ``zval`` of type ``IS_OBJECT``
+pointing to the singleton case object.
+
+Iterate over all cases::
+
+    zend_string *case_name;
+    zend_class_constant *c;
+
+    ZEND_HASH_FOREACH_STR_KEY_PTR(CE_CONSTANTS_TABLE(my_enum_ce), case_name, c) {
+        if (ZEND_CLASS_CONST_FLAGS(c) & ZEND_CLASS_CONST_IS_CASE) {
+            zval *case_zv = &c->value;
+            zend_object *case_obj = Z_OBJ_P(case_zv);
+            /* ... */
+        }
+    } ZEND_HASH_FOREACH_END();
+
+The backed enum table
+---------------------
+
+For backed enums, a reverse-lookup ``HashTable`` (accessible via ``CE_BACKED_ENUM_TABLE(ce)``) maps
+backing values to case names. This is what powers ``MyEnum::from()`` and ``MyEnum::tryFrom()``.
+
+Defining an internal enum from C
+----------------------------------
+
+Extensions can define enum types using ``zend_register_internal_enum()``.
+
+**Register the enum class**::
+
+    zend_class_entry *my_enum_ce = zend_register_internal_enum(
+        "MyExtension\\Status",
+        IS_STRING,           /* backing type: IS_UNDEF, IS_LONG, or IS_STRING */
+        my_enum_methods      /* additional methods, or NULL */
+    );
+
+This handles everything automatically: sets ``ZEND_ACC_ENUM``, allocates the backed enum table,
+and registers the built-in methods ``cases()``, ``from()``, and ``tryFrom()``.
+
+**Add enum cases**::
+
+    /* For a string-backed enum */
+    zval val;
+
+    ZVAL_STRING(&val, "active");
+    zend_enum_add_case_cstr(my_enum_ce, "Active", &val);
+    zval_ptr_dtor(&val);
+
+    ZVAL_STRING(&val, "inactive");
+    zend_enum_add_case_cstr(my_enum_ce, "Inactive", &val);
+    zval_ptr_dtor(&val);
+
+For a pure enum, pass ``NULL`` as the value::
+
+    zend_enum_add_case_cstr(my_unit_enum_ce, "CaseA", NULL);
+    zend_enum_add_case_cstr(my_unit_enum_ce, "CaseB", NULL);
+
+For an int-backed enum::
+
+    ZVAL_LONG(&val, 1);
+    zend_enum_add_case_cstr(my_int_enum_ce, "One", &val);
+
+**Retrieve a case by name**::
+
+    zend_object *case_obj = zend_enum_get_case_cstr(my_enum_ce, "Active");
+    if (case_obj) {
+        /* Use the case singleton */
+    }
+
+**Retrieve a case by backing value** (implements ``from()``/``tryFrom()`` semantics)::
+
+    zend_object *result = NULL;
+    zend_result rc = zend_enum_get_case_by_value(
+        &result,
+        my_enum_ce,
+        /* long_key */ 0,           /* used only if backing type is IS_LONG */
+        /* string_key */ ZSTR_INIT_LITERAL("active", 0),
+        /* try_from */ true         /* false = throw ValueError on not found */
+    );
+
+    if (rc == SUCCESS && result != NULL) {
+        /* result is the case object */
+    }
+
+The full public API
+--------------------
+
+The complete C API for enums is declared in ``Zend/zend_enum.h``:
+
+.. list-table::
+    :header-rows: 1
+
+    * - Function
+      - Description
+    * - ``zend_register_internal_enum(name, type, methods)``
+      - Register a new internal enum class.
+    * - ``zend_enum_add_case(ce, name_str, value_zv)``
+      - Add a case (``zend_string*`` name, nullable ``zval*`` value).
+    * - ``zend_enum_add_case_cstr(ce, name, value_zv)``
+      - Add a case (``const char*`` name).
+    * - ``zend_enum_get_case(ce, name)``
+      - Look up a case by ``zend_string*`` name.
+    * - ``zend_enum_get_case_cstr(ce, name)``
+      - Look up a case by ``const char*`` name.
+    * - ``zend_enum_get_case_by_value(result, ce, long_key, str_key, try_from)``
+      - Look up a case by backing value.
+    * - ``zend_enum_fetch_case_name(zobj)``
+      - Return ``zval*`` for the ``name`` property of a case object.
+    * - ``zend_enum_fetch_case_value(zobj)``
+      - Return ``zval*`` for the ``value`` property (backed enums only).
+    * - ``zend_enum_new(result, ce, case_name, backing_value_zv)``
+      - Low-level: allocate a new case object (use ``zend_enum_add_case`` instead).
+
+Using an enum case as a function argument
+------------------------------------------
+
+When a function in your extension accepts an enum value, declare the parameter type in the stub file
+using the enum class name::
+
+    function set_status(MyExtension\Status $status): void {}
+
+In the function body, receive it as a ``zend_object*`` and verify it is the expected enum::
+
+    PHP_FUNCTION(set_status)
+    {
+        zend_object *status_obj;
+
+        ZEND_PARSE_PARAMETERS_START(1, 1)
+            Z_PARAM_OBJ_OF_CLASS(status_obj, my_enum_ce)
+        ZEND_PARSE_PARAMETERS_END();
+
+        /* Get the string backing value */
+        zval *value = zend_enum_fetch_case_value(status_obj);
+        zend_string *status_str = Z_STR_P(value);
+
+        /* ... */
+    }
+
+Object identity and comparison
+--------------------------------
+
+Enum cases are singletons. The same case always yields the same ``zend_object*`` pointer. You can
+compare two enum values with ``==`` at the pointer level, or use the standard ``zend_objects_compare``
+which the enum's ``compare`` object handler delegates to.
+
+Do not use ``clone`` on enum cases -- the ``clone_obj`` handler is set to ``NULL``, so attempting to
+clone an enum case throws an ``Error``.

--- a/Book/php7/extensions_design.rst
+++ b/Book/php7/extensions_design.rst
@@ -19,4 +19,8 @@ Contents:
     extensions_design/hooks.rst
     extensions_design/ini_settings.rst
     extensions_design/zend_extensions.rst
+    extensions_design/stub_files.rst
+    extensions_design/named_arguments.rst
+    extensions_design/attributes.rst
+    extensions_design/observer_api.rst
 

--- a/Book/php7/extensions_design/attributes.rst
+++ b/Book/php7/extensions_design/attributes.rst
@@ -1,0 +1,250 @@
+Attributes
+==========
+
+.. versionadded:: PHP 8.0
+
+   Attributes were introduced in PHP 8.0 and are not available in PHP 7.
+
+PHP 8.0 introduced attributes (also known as annotations in other languages). Attributes allow you to attach
+structured metadata to classes, functions, methods, properties, class constants, and function parameters,
+using the ``#[AttributeClass(args...)]`` syntax::
+
+    #[Attribute]
+    class MyAttr {
+        public function __construct(public readonly int $value) {}
+    }
+
+    #[MyAttr(42)]
+    function my_function(): void {}
+
+This chapter explains how attributes are represented internally, how extensions can read attributes attached
+to declarations, and how to define attribute classes from C.
+
+Internal representation
+------------------------
+
+Each attribute annotation is stored as a ``zend_attribute`` struct, defined in ``Zend/zend_attributes.h``::
+
+    typedef struct _zend_attribute {
+        zend_string *name;    /* fully-qualified attribute class name */
+        zend_string *lcname;  /* lowercased for lookup */
+        uint32_t     flags;   /* ZEND_ATTRIBUTE_PERSISTENT | ZEND_ATTRIBUTE_STRICT_TYPES */
+        uint32_t     lineno;
+        uint32_t     offset;  /* 0 for class/function/property/const;
+                                 1-based parameter index for parameters */
+        uint32_t     argc;
+        zend_attribute_arg args[1]; /* flexible array */
+    } zend_attribute;
+
+Each argument is a ``zend_attribute_arg``::
+
+    typedef struct {
+        zend_string *name;  /* argument name (NULL for positional arguments) */
+        zval         value; /* the argument value as a compile-time constant zval */
+    } zend_attribute_arg;
+
+Attributes are stored on the relevant declaration as a ``HashTable *attributes`` pointer:
+
+.. list-table::
+    :header-rows: 1
+
+    * - Declaration
+      - Field
+    * - Class
+      - ``zend_class_entry.attributes``
+    * - Function / method
+      - ``zend_function.common.attributes``
+    * - Property
+      - ``zend_property_info.attributes``
+    * - Class constant
+      - ``zend_class_constant.attributes``
+    * - Parameter
+      - same as function, distinguished by ``zend_attribute.offset`` (1-based)
+
+The hash table keys are the lowercased attribute class names. Multiple attributes of the same class on the
+same declaration are stored under a shared key as a linked list (when the attribute class has
+``ZEND_ATTRIBUTE_IS_REPEATABLE`` set) or as a single entry (otherwise).
+
+Reading attributes from C
+--------------------------
+
+Use the ``zend_get_attribute*`` family of functions to look up attributes by name.
+
+**On a function or method**::
+
+    /* Look up #[MyAttr] on a function. The name must be lowercased. */
+    zend_attribute *attr = zend_get_attribute_str(
+        func->common.attributes,
+        "myattr",
+        sizeof("myattr") - 1
+    );
+
+    if (attr != NULL) {
+        /* attribute is present */
+        if (attr->argc >= 1) {
+            zval value;
+            zend_result result = zend_get_attribute_value(
+                &value, attr, /* arg index */ 0, func->common.scope);
+
+            if (result == SUCCESS) {
+                /* use value ... */
+                zval_ptr_dtor(&value);
+            }
+        }
+    }
+
+**On a class**::
+
+    zend_attribute *attr = zend_get_attribute_str(
+        ce->attributes,
+        "myattr",
+        sizeof("myattr") - 1
+    );
+
+**On a property**::
+
+    zend_property_info *prop_info = zend_hash_str_find_ptr(
+        &ce->properties_info, "myprop", sizeof("myprop") - 1);
+
+    if (prop_info && prop_info->attributes) {
+        zend_attribute *attr = zend_get_attribute_str(
+            prop_info->attributes, "myattr", sizeof("myattr") - 1);
+    }
+
+**On a parameter** (1-based index)::
+
+    zend_attribute *attr = zend_get_parameter_attribute_str(
+        func->common.attributes,
+        "myattr",
+        sizeof("myattr") - 1,
+        /* offset = */ 1  /* first parameter */
+    );
+
+**Evaluating attribute argument values**
+
+Attribute arguments are stored as compile-time constant expressions. They may be literals (integers,
+strings, ``true``/``false``/``null``), class constants, or constant expressions. Use
+``zend_get_attribute_value()`` to resolve them to a runtime ``zval``::
+
+    zval value;
+    if (zend_get_attribute_value(&value, attr, 0, scope) == SUCCESS) {
+        if (Z_TYPE(value) == IS_LONG) {
+            zend_long n = Z_LVAL(value);
+        } else if (Z_TYPE(value) == IS_STRING) {
+            zend_string *s = Z_STR(value);
+        }
+        zval_ptr_dtor(&value);
+    }
+
+Attribute target flags
+-----------------------
+
+When registering an internal attribute class, you specify which declaration targets it is allowed on.
+These are controlled by the ``ZEND_ATTRIBUTE_TARGET_*`` flags::
+
+    #define ZEND_ATTRIBUTE_TARGET_CLASS        (1 << 0)
+    #define ZEND_ATTRIBUTE_TARGET_FUNCTION     (1 << 1)
+    #define ZEND_ATTRIBUTE_TARGET_METHOD       (1 << 2)
+    #define ZEND_ATTRIBUTE_TARGET_PROPERTY     (1 << 3)
+    #define ZEND_ATTRIBUTE_TARGET_CLASS_CONST  (1 << 4)
+    #define ZEND_ATTRIBUTE_TARGET_PARAMETER    (1 << 5)
+    #define ZEND_ATTRIBUTE_TARGET_ALL          ((1 << 6) - 1)
+    #define ZEND_ATTRIBUTE_IS_REPEATABLE       (1 << 6)
+
+Combine flags with ``|``::
+
+    ZEND_ATTRIBUTE_TARGET_FUNCTION | ZEND_ATTRIBUTE_TARGET_METHOD
+
+Registering an internal attribute class
+-----------------------------------------
+
+To define a built-in C extension attribute that PHP userland can use:
+
+**Step 1: Register the class entry** (in MINIT)::
+
+    static zend_class_entry ce;
+    INIT_CLASS_ENTRY(ce, "MyExtension\\SomeAttr", myattr_methods);
+    zend_class_entry *myattr_ce = zend_register_internal_class(&ce);
+
+**Step 2: Mark it as an attribute**::
+
+    zend_internal_attribute *int_attr = zend_internal_attribute_register(
+        myattr_ce,
+        ZEND_ATTRIBUTE_TARGET_FUNCTION | ZEND_ATTRIBUTE_TARGET_METHOD
+    );
+
+**Step 3: Optionally, add a validator callback**::
+
+    int_attr->validator = my_attr_validator;
+
+The validator is called at class-link time (when the class containing the attribute is first used).
+Its signature is::
+
+    static void my_attr_validator(zend_attribute *attr,
+                                  uint32_t target,
+                                  zend_class_entry *scope)
+    {
+        /* Validate attribute arguments. Throw a TypeError or
+         * ValueError if the arguments are invalid. */
+        if (attr->argc < 1) {
+            zend_type_error("SomeAttr requires at least one argument");
+        }
+    }
+
+Attaching attributes to internal declarations from C
+-----------------------------------------------------
+
+If you want to attach attributes to your own internal functions, properties, or class constants
+programmatically from C, use the ``zend_add_*_attribute()`` helpers::
+
+    /* Attach #[MyAttr(1)] to a function */
+    zend_attribute *a = zend_add_function_attribute(
+        zend_hash_str_find_ptr(EG(function_table), "my_func", sizeof("my_func") - 1),
+        zend_string_init("myattr", sizeof("myattr") - 1, 1),
+        /* argc */ 1
+    );
+    ZVAL_LONG(&a->args[0].value, 1);
+    a->args[0].name = NULL; /* positional argument */
+
+Built-in attribute class entries
+----------------------------------
+
+The engine exports the following built-in attribute class entries for use in extension code:
+
+.. list-table::
+    :header-rows: 1
+
+    * - Variable
+      - PHP class
+    * - ``zend_ce_attribute``
+      - ``Attribute``
+    * - ``zend_ce_allow_dynamic_properties``
+      - ``AllowDynamicProperties`` (PHP 8.2+)
+    * - ``zend_ce_sensitive_parameter``
+      - ``SensitiveParameter`` (PHP 8.2+)
+    * - ``zend_ce_sensitive_parameter_value``
+      - ``SensitiveParameterValue`` (PHP 8.2+)
+    * - ``zend_ce_override``
+      - ``Override`` (PHP 8.3+)
+    * - ``zend_ce_deprecated``
+      - ``Deprecated`` (PHP 8.4+)
+
+These can be used to check whether a declaration carries a known built-in attribute, or to register
+your own class as a subclass of one of them.
+
+The ``SensitiveParameter`` attribute
+--------------------------------------
+
+.. versionadded:: PHP 8.2
+
+PHP 8.2 added the ``#[SensitiveParameter]`` attribute, which marks a function parameter as sensitive.
+When a ``Throwable`` is caught and its backtrace is inspected, argument values for parameters marked
+``#[SensitiveParameter]`` are replaced with a ``SensitiveParameterValue`` object. This prevents
+passwords, keys, and similar values from appearing in stack traces.
+
+For internal functions, declare the attribute in the stub file::
+
+    function my_login(string $username, #[\SensitiveParameter] string $password): bool {}
+
+``gen_stub.php`` will emit the attribute in the generated arginfo. The engine checks for this attribute
+automatically when building exception backtraces.

--- a/Book/php7/extensions_design/named_arguments.rst
+++ b/Book/php7/extensions_design/named_arguments.rst
@@ -1,0 +1,175 @@
+Named arguments
+===============
+
+.. versionadded:: PHP 8.0
+
+   Named arguments were introduced in PHP 8.0 and are not available in PHP 7.
+
+PHP 8.0 introduced named arguments, which allow callers to pass function arguments by name rather than by
+position. For example::
+
+    // PHP userland
+    array_slice(array: $a, offset: 2, length: 3, preserve_keys: true);
+
+This chapter covers how named arguments work internally, and what extension authors must do to support them.
+
+How named arguments work at the call site
+------------------------------------------
+
+At the call site, the PHP compiler handles named arguments in two different ways depending on whether the
+call target is known at compile time:
+
+**Statically known target (most common)**
+    When calling a named function or a method via a class literal (``Foo::bar()``), the compiler resolves
+    the argument names against the target function's arginfo at compile time. It reorders the arguments
+    into positional order before emitting the call opcodes. From the callee's perspective, the arguments
+    arrive in the expected positional slots and there is nothing special to handle.
+
+**Dynamically dispatched target**
+    When calling through a variable (``$fn()``), ``call_user_func()``, ``Closure::call()``, and similar
+    dynamic dispatch paths, the VM resolves named arguments at runtime using
+    ``zend_handle_named_arg()``. Arguments that match declared parameter names by name are placed in the
+    correct positional slots. Arguments that do not match any parameter name (overflow named args for a
+    variadic function) are stored in ``execute_data->extra_named_params``.
+
+The ``extra_named_params`` hash table
+---------------------------------------
+
+When named arguments overflow (because the function is variadic and the named argument does not correspond
+to any fixed parameter), they are stored in the ``extra_named_params`` field of ``zend_execute_data``::
+
+    struct _zend_execute_data {
+        /* ... other fields ... */
+        zend_array *extra_named_params;
+    };
+
+This field is ``NULL`` for most calls. The ``ZEND_CALL_HAS_EXTRA_NAMED_PARAMS`` flag (bit 27 of the call
+info word) is set when extra named params are present.
+
+After the function returns, the engine frees this hash table automatically.
+
+What extension functions must do
+----------------------------------
+
+**Non-variadic functions**: Nothing special. The ZPP system (``ZEND_PARSE_PARAMETERS_START`` and
+``Z_PARAM_*``) handles positionally-resolved named arguments transparently. You do not need to change
+anything in the function body.
+
+**Variadic functions**: If your variadic function accepts named arguments, use
+``Z_PARAM_VARIADIC_WITH_NAMED`` to capture both the positional variadic arguments and the overflow
+named params::
+
+    PHP_FUNCTION(my_variadic)
+    {
+        zval     *args       = NULL;
+        uint32_t  args_count = 0;
+        HashTable *named     = NULL;
+
+        ZEND_PARSE_PARAMETERS_START(0, -1)
+            Z_PARAM_VARIADIC_WITH_NAMED(args, args_count, named)
+        ZEND_PARSE_PARAMETERS_END();
+
+        /* args[0..args_count-1] hold the positional variadic arguments */
+
+        if (named) {
+            zend_string *key;
+            zval *val;
+            ZEND_HASH_FOREACH_STR_KEY_VAL(named, key, val) {
+                /* key: argument name, val: its value */
+            } ZEND_HASH_FOREACH_END();
+        }
+    }
+
+The ``named`` pointer may be ``NULL`` if no named arguments were passed. Do not free it -- the engine
+owns this hash table.
+
+Requiring proper parameter names in arginfo
+--------------------------------------------
+
+For named arguments to work, each parameter in the function's arginfo must have a real name. The
+:doc:`stub file system <stub_files>` always generates correct parameter names from the stub.
+
+With hand-written arginfo, using an empty string ``""`` as a parameter name silently disables named
+argument support for that parameter::
+
+    /* Broken: empty parameter names prevent named argument use */
+    ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_bad, 0, 2, IS_LONG, 0)
+        ZEND_ARG_TYPE_INFO(0, "", IS_LONG, 0)  /* name "" breaks named args */
+        ZEND_ARG_TYPE_INFO(0, "", IS_LONG, 0)
+    ZEND_END_ARG_INFO()
+
+    /* Correct: real names */
+    ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_good, 0, 2, IS_LONG, 0)
+        ZEND_ARG_TYPE_INFO(0, a, IS_LONG, 0)
+        ZEND_ARG_TYPE_INFO(0, b, IS_LONG, 0)
+    ZEND_END_ARG_INFO()
+
+Disabling named arguments
+--------------------------
+
+Some functions cannot meaningfully support named arguments -- for example, functions that use ``func_get_args()``
+internally, or functions where argument names are not stable parts of the public API. To opt out of named
+argument support for a function, use the ``ZEND_ACC_NO_NAMED_ARGS`` flag::
+
+    static const zend_function_entry myext_functions[] = {
+        ZEND_RAW_FENTRY("myext_internal", zif_myext_internal, arginfo_myext_internal,
+            ZEND_ACC_NO_NAMED_ARGS, NULL, NULL)
+        ZEND_FE_END
+    };
+
+When ``ZEND_ACC_NO_NAMED_ARGS`` is set, calling the function with named arguments throws a ``TypeError``.
+
+Calling PHP functions with named arguments from C
+--------------------------------------------------
+
+To call a PHP function from C code and pass named arguments, populate the ``named_params`` field of
+``zend_fcall_info``::
+
+    zend_fcall_info fci = {0};
+    zend_fcall_info_cache fcc = {0};
+
+    /* Build the named args HashTable */
+    HashTable *named = emalloc(sizeof(HashTable));
+    zend_hash_init(named, 2, NULL, ZVAL_PTR_DTOR, 0);
+
+    zval val;
+    ZVAL_LONG(&val, 42);
+    zend_hash_str_add(named, "level", sizeof("level") - 1, &val);
+
+    fci.size = sizeof(fci);
+    fci.named_params = named;
+    ZVAL_UNDEF(&fci.function_name); /* set appropriately */
+    fci.retval = &retval;
+    fci.param_count = 0;
+    fci.params = NULL;
+
+    zend_call_function(&fci, &fcc);
+
+    zend_hash_destroy(named);
+    efree(named);
+
+Alternatively, use ``zend_call_known_function()`` which accepts a ``named_params`` pointer directly::
+
+    zend_call_known_function(
+        fn,           /* zend_function* */
+        object,       /* zend_object* or NULL */
+        called_scope, /* zend_class_entry* or NULL */
+        &retval,      /* zval* return value */
+        0,            /* param_count */
+        NULL,         /* params */
+        named         /* named_params HashTable* */
+    );
+
+Pass ``NULL`` for ``named_params`` when there are no named arguments.
+
+Named arguments and reflection
+--------------------------------
+
+From a reflection perspective, the names declared in arginfo are what PHP's ``ReflectionParameter::getName()``
+returns. Using the stub file system ensures these names match the stub exactly, which is what callers see
+when they look up parameter names for a call like::
+
+    $ref = new ReflectionFunction('myext_add');
+    foreach ($ref->getParameters() as $p) {
+        echo $p->getName() . "\n";  // prints the stub parameter names
+    }

--- a/Book/php7/extensions_design/observer_api.rst
+++ b/Book/php7/extensions_design/observer_api.rst
@@ -1,0 +1,253 @@
+Observer API
+============
+
+.. versionadded:: PHP 8.0
+
+   The Observer API was introduced in PHP 8.0. In PHP 7, the only way to observe every function call
+   was to overwrite global function pointers such as ``zend_execute_ex`` and ``zend_execute_internal``,
+   which was fragile and incompatible with other extensions.
+
+Before PHP 8, extensions that needed to observe every function call (for profilers, debuggers, APM agents,
+and similar tools) had no official hook. The common approach was to overwrite global function pointers such
+as ``zend_execute_ex``, ``zend_execute_internal``, and ``zend_error_cb``, or to replace individual opcode
+handlers. These techniques were fragile and incompatible with each other and with the JIT compiler.
+
+PHP 8.0 introduced the **Observer API** as an officially supported, composable mechanism for observing
+function execution and other engine events. Multiple extensions can register observers simultaneously
+without interfering with each other, and the observer hooks are JIT-compatible.
+
+The Observer API is defined in ``Zend/zend_observer.h``.
+
+The function call observer
+---------------------------
+
+The core of the Observer API is a per-function ``begin``/``end`` handler pair. The typical workflow is:
+
+1. Register a factory function (``zend_observer_fcall_init``) during ``MINIT``.
+2. The engine calls your factory the first time each function runs (lazily).
+3. Your factory inspects the function and returns either ``{NULL, NULL}`` (opt out) or a
+   ``{begin, end}`` handler pair.
+4. The engine caches the handlers and calls them at the start and end of every subsequent call.
+
+**Handler types**::
+
+    typedef void (*zend_observer_fcall_begin_handler)(zend_execute_data *execute_data);
+    typedef void (*zend_observer_fcall_end_handler)(zend_execute_data *execute_data,
+                                                     zval *retval);
+
+    typedef struct _zend_observer_fcall_handlers {
+        zend_observer_fcall_begin_handler begin;
+        zend_observer_fcall_end_handler   end;
+    } zend_observer_fcall_handlers;
+
+**Factory type**::
+
+    typedef zend_observer_fcall_handlers (*zend_observer_fcall_init)(
+        zend_execute_data *execute_data);
+
+**Registration** (must be called during ``MINIT``)::
+
+    ZEND_API void zend_observer_fcall_register(zend_observer_fcall_init init_fn);
+
+A minimal profiling extension
+-------------------------------
+
+Here is a complete example of a profiling extension that records wall-clock time for every function call::
+
+    #include "zend_observer.h"
+    #include <time.h>
+
+    /* Per-call state stored on the VM stack */
+    typedef struct {
+        struct timespec start;
+    } my_call_state;
+
+    static void my_begin(zend_execute_data *execute_data)
+    {
+        zend_function *fn = execute_data->func;
+        /* Allocate state on the VM stack if needed; for simplicity,
+         * use a static here (not thread-safe). */
+        clock_gettime(CLOCK_MONOTONIC, &((my_call_state *)
+            ZEND_OBSERVER_DATA(execute_data, zend_observer_fcall_op_array_extension)
+        )->start);
+    }
+
+    static void my_end(zend_execute_data *execute_data, zval *retval)
+    {
+        struct timespec end;
+        clock_gettime(CLOCK_MONOTONIC, &end);
+
+        zend_function *fn = execute_data->func;
+        if (fn->common.function_name) {
+            /* compute elapsed and record ... */
+        }
+    }
+
+    static zend_observer_fcall_handlers my_init(zend_execute_data *execute_data)
+    {
+        zend_function *fn = execute_data->func;
+
+        /* Skip functions without a name (top-level script) */
+        if (!fn->common.function_name) {
+            return (zend_observer_fcall_handlers){NULL, NULL};
+        }
+
+        return (zend_observer_fcall_handlers){my_begin, my_end};
+    }
+
+    PHP_MINIT_FUNCTION(myprofiler)
+    {
+        zend_observer_fcall_register(my_init);
+        return SUCCESS;
+    }
+
+The ``my_init`` function is called **once per function**, the first time that function executes. Returning
+``{NULL, NULL}`` means "do not observe this function". The choice is cached permanently (until the next
+request or opcache reset), so the factory is not called again for the same function.
+
+Observing internal functions
+-----------------------------
+
+By default in PHP 8.0, the observer factory was only called for user-defined (PHP) functions. PHP 8.2
+changed this: ``zend_observer_fcall_init`` handlers are now also called for internal (C) functions. If
+your factory should only observe PHP functions, check ``fn->type``::
+
+    static zend_observer_fcall_handlers my_init(zend_execute_data *execute_data)
+    {
+        zend_function *fn = execute_data->func;
+
+        if (fn->type != ZEND_USER_FUNCTION) {
+            return (zend_observer_fcall_handlers){NULL, NULL};
+        }
+
+        /* ... */
+    }
+
+Runtime handler management
+---------------------------
+
+In addition to the factory registration, the Observer API allows adding and removing handlers per-function
+at runtime::
+
+    /* Add a begin handler for a specific function */
+    ZEND_API void zend_observer_add_begin_handler(
+        zend_function *function,
+        zend_observer_fcall_begin_handler begin);
+
+    /* Remove a begin handler (returns true if removed, false if not found).
+     * The next parameter receives the handler that should be called if removal
+     * happened during observer execution (PHP 8.4+). */
+    ZEND_API bool zend_observer_remove_begin_handler(
+        zend_function *function,
+        zend_observer_fcall_begin_handler begin,
+        zend_observer_fcall_begin_handler *next);
+
+    /* Same for end handlers */
+    ZEND_API void zend_observer_add_end_handler(
+        zend_function *function,
+        zend_observer_fcall_end_handler end);
+    ZEND_API bool zend_observer_remove_end_handler(
+        zend_function *function,
+        zend_observer_fcall_end_handler end,
+        zend_observer_fcall_end_handler *next);
+
+Only one begin handler and one end handler can be active simultaneously for a given function. Remove the
+existing handler before adding a replacement.
+
+Other observable events
+------------------------
+
+The Observer API covers several engine events beyond function calls:
+
+**Function declaration** (compile time)::
+
+    typedef void (*zend_observer_function_declared_cb)(
+        zend_op_array *op_array, zend_string *name);
+
+    ZEND_API void zend_observer_function_declared_register(
+        zend_observer_function_declared_cb cb);
+
+Called when a PHP function or method is defined (i.e., when its containing file is compiled).
+
+**Class linking**::
+
+    typedef void (*zend_observer_class_linked_cb)(
+        zend_class_entry *ce, zend_string *name);
+
+    ZEND_API void zend_observer_class_linked_register(
+        zend_observer_class_linked_cb cb);
+
+Called when a class is linked (its parent class, interfaces, and traits are resolved). This is the
+appropriate place to act on class-level attributes.
+
+**Error notification**::
+
+    typedef void (*zend_observer_error_cb)(
+        int type, zend_string *error_filename,
+        uint32_t error_lineno, zend_string *message);
+
+    ZEND_API void zend_observer_error_register(zend_observer_error_cb callback);
+
+This is the replacement for the old pattern of overwriting ``zend_error_cb``. Use this instead. Multiple
+extensions can each register their own error callback without conflicting.
+
+**Fiber lifecycle** (PHP 8.1+)::
+
+    typedef void (*zend_observer_fiber_init_handler)(zend_fiber_context *initializing);
+    typedef void (*zend_observer_fiber_switch_handler)(zend_fiber_context *from,
+                                                       zend_fiber_context *to);
+    typedef void (*zend_observer_fiber_destroy_handler)(zend_fiber_context *destroying);
+
+    ZEND_API void zend_observer_fiber_init_register(
+        zend_observer_fiber_init_handler handler);
+    ZEND_API void zend_observer_fiber_switch_register(
+        zend_observer_fiber_switch_handler handler);
+    ZEND_API void zend_observer_fiber_destroy_register(
+        zend_observer_fiber_destroy_handler handler);
+
+These callbacks are called when a fiber is created, when execution switches between fibers (or between
+a fiber and the main thread), and when a fiber is destroyed. This is essential for profilers and APM tools
+that track per-fiber execution time or context.
+
+Checking if the observer system is active
+------------------------------------------
+
+The observer infrastructure has a small overhead even when no observers are registered, because the engine
+must check whether to call observer hooks. You can test whether any observers are active::
+
+    if (ZEND_OBSERVER_ENABLED) {
+        /* At least one observer factory has been registered */
+    }
+
+``ZEND_OBSERVER_ENABLED`` is defined as::
+
+    #define ZEND_OBSERVER_ENABLED \
+        (zend_observer_fcall_op_array_extension != -1)
+
+This is a fast global check. It is set to ``-1`` (disabled) at startup and changed to a valid extension
+slot handle the first time a factory is registered.
+
+The ``ZEND_CALL_OBSERVED`` flag
+---------------------------------
+
+When an observer begin handler is active for a function, the engine sets the
+``ZEND_CALL_OBSERVED`` flag (bit 28) in the call info word of the current ``zend_execute_data``. This
+enables the fast path for the end handler: the engine knows it must call the end handler without
+checking the handler table again.
+
+If your observer needs to know whether the current call is observed from within the ``begin`` handler, you
+can check::
+
+    if (ZEND_CALL_INFO(execute_data) & ZEND_CALL_OBSERVED) {
+        /* We are inside an observed call */
+    }
+
+Compatibility with the JIT
+----------------------------
+
+The Observer API is fully compatible with the JIT compiler. The JIT respects observer hooks and does not
+optimise away observed function calls. This is one of the key advantages of the Observer API over the
+old approach of overwriting ``zend_execute_ex`` -- the latter caused the JIT to disable itself entirely.
+
+If your extension only uses the Observer API (and not ``zend_execute_ex`` or custom opcode handlers), the
+JIT will remain active and your extension will benefit from JIT-compiled PHP code alongside its observing.

--- a/Book/php7/extensions_design/php_functions.rst
+++ b/Book/php7/extensions_design/php_functions.rst
@@ -162,6 +162,19 @@ function could have worked if we would have written its body now. Even with no d
           information about the function. Arguments are also used by the engine, especially when we talk about
           arguments passed by reference, or functions returning references.
 
+.. versionchanged:: PHP 8.0
+
+   As of PHP 8.0, declaring arginfo is **mandatory** for all internal functions. Extensions that
+   omit it produce a startup warning. Use the :doc:`stub file system <stub_files>` to generate
+   arginfo automatically from a plain PHP signature file.
+
+   The ``zend_internal_arg_info`` structure was also significantly changed in PHP 8: the
+   ``class_name`` and ``type_hint`` fields were replaced by a single ``zend_type type`` field
+   that can represent union types, intersection types, and named class types. The old macros
+   still exist, but new code should use the stub file system to generate correct arginfo rather
+   than writing it by hand. See :doc:`stub_files` and :doc:`../internal_types/type_system` for
+   the full details.
+
 To declare arguments, we need to familiarize with the ``zend_internal_arg_info`` structure::
 
     typedef struct _zend_internal_arg_info {

--- a/Book/php7/extensions_design/stub_files.rst
+++ b/Book/php7/extensions_design/stub_files.rst
@@ -1,0 +1,276 @@
+Stub files
+==========
+
+.. versionadded:: PHP 8.0
+
+   Stub files are a PHP 8.0+ feature. PHP 7 extensions must write arginfo by hand using the
+   ``ZEND_BEGIN_ARG_*`` macro family directly.
+
+Before PHP 8, declaring function signatures for internal (C extension) functions required writing
+``zend_internal_arg_info`` arrays by hand using a family of ``ZEND_ARG_*`` and ``ZEND_BEGIN_ARG_*`` macros.
+This was error-prone and verbose -- especially for functions with union types, nullable types, or many
+parameters.
+
+PHP 8 introduces **stub files**: plain PHP files (``*.stub.php``) that describe function, class, interface,
+and enum signatures using normal PHP 8 syntax. A code generator, ``build/gen_stub.php`` from the PHP source
+tree, reads these stub files and produces the corresponding ``*_arginfo.h`` C header. The generated header
+is what you include in your extension.
+
+This approach means you write natural PHP type hints once and get correct, complete arginfo for free.
+
+.. note:: As of PHP 8.0, all internal functions must declare arginfo. Using stub files is the recommended
+          way to satisfy this requirement. Undeclared functions produce a warning at startup.
+
+Stub file syntax
+-----------------
+
+A stub file is a valid PHP file, but with empty function bodies and special constant placeholder values.
+Here is a minimal example, ``myext.stub.php``::
+
+    <?php
+
+    /** @generate-class-entries */
+
+    function myext_hello(string $name = "world"): string {}
+
+    function myext_add(int $a, int $b): int {}
+
+    function myext_parse(string $input, int $flags = 0): array|false {}
+
+Key rules:
+
+* Function bodies are always empty ``{}``.
+* Types use normal PHP 8 syntax: ``?T``, ``T|U``, ``T&U``, ``(T&U)|null``.
+* Default values are written as PHP expressions. ``gen_stub.php`` stores the string representation of the
+  default for use in reflection; the actual default value logic is still in your C code.
+* Constants must be declared with a value of ``UNKNOWN`` because their values come from C ``#define``
+  directives and are not known at stub-parse time: ``const MY_FLAG = UNKNOWN;``
+* Use ``/** @generate-class-entries */`` on classes/interfaces/enums to instruct ``gen_stub.php`` to emit
+  the ``register_class_*()`` function that registers the class.
+
+Generating the arginfo header
+------------------------------
+
+Run ``gen_stub.php`` from the PHP source tree, passing your stub file as the argument::
+
+    php /path/to/php-src/build/gen_stub.php ext/myext/myext.stub.php
+
+This writes (or updates) ``ext/myext/myext_arginfo.h``. The generated header contains:
+
+* A ``static const zend_internal_arg_info`` array for each function.
+* ``ZEND_FUNCTION(name)`` forward declarations.
+* A ``static const zend_function_entry ext_functions[]`` table.
+* ``register_class_*()`` functions for any declared classes.
+* A stub hash comment so you can detect when regeneration is needed.
+
+The generated file should be committed to your repository alongside the stub file. Regenerate it whenever
+you change the stub.
+
+A complete example
+-------------------
+
+Suppose your stub file is::
+
+    <?php
+
+    function myext_compress(string $data, int $level = -1): string|false {}
+
+    function myext_decompress(string $data): string {}
+
+The generated ``myext_arginfo.h`` will look like::
+
+    /* This is a generated file, edit the .stub.php file instead.
+     * Stub hash: <sha1 of stub file> */
+
+    ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_myext_compress, 0, 1,
+            MAY_BE_STRING|MAY_BE_FALSE)
+        ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+        ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, level, IS_LONG, 0, "-1")
+    ZEND_END_ARG_INFO()
+
+    ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_myext_decompress, 0, 1,
+            IS_STRING, 0)
+        ZEND_ARG_TYPE_INFO(0, data, IS_STRING, 0)
+    ZEND_END_ARG_INFO()
+
+    ZEND_FUNCTION(myext_compress);
+    ZEND_FUNCTION(myext_decompress);
+
+    static const zend_function_entry ext_functions[] = {
+        ZEND_FE(myext_compress, arginfo_myext_compress)
+        ZEND_FE(myext_decompress, arginfo_myext_decompress)
+        ZEND_FE_END
+    };
+
+In your main extension file, include the generated header and use the ``ext_functions`` table::
+
+    #include "myext_arginfo.h"
+
+    zend_module_entry myext_module_entry = {
+        STANDARD_MODULE_HEADER,
+        "myext",
+        ext_functions,
+        /* ... */
+        STANDARD_MODULE_PROPERTIES
+    };
+
+Understanding the generated arginfo macros
+-------------------------------------------
+
+The ``ZEND_BEGIN_ARG_*`` family of macros declares the ``zend_internal_arg_info`` array for one function.
+The first element of this array is special: rather than describing a parameter, it carries the return type
+and the number of required arguments.
+
+**Choosing the right opener macro**
+
+.. list-table::
+    :header-rows: 1
+
+    * - Return type
+      - Macro to use
+    * - ``void``
+      - ``ZEND_BEGIN_ARG_INFO_EX(name, 0, return_ref, req_args)``
+    * - Single primitive (e.g. ``IS_LONG``)
+      - ``ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(name, return_ref, req_args, type_code, allow_null)``
+    * - Primitive bitmask (e.g. ``string|false``)
+      - ``ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(name, return_ref, req_args, type_mask)``
+    * - Object / class
+      - ``ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(name, return_ref, req_args, class_name, allow_null)``
+    * - Object + primitives (e.g. ``Foo|false``)
+      - ``ZEND_BEGIN_ARG_WITH_RETURN_OBJ_TYPE_MASK_EX(name, return_ref, req, class, type_mask)``
+
+For interface/abstract methods whose return types are "tentative" (declared but not yet enforced for
+covariance purposes), use the ``_WITH_TENTATIVE_RETURN_*`` variants.
+
+**Per-parameter macros**
+
+.. list-table::
+    :header-rows: 1
+
+    * - Parameter type
+      - Macro
+    * - No type hint
+      - ``ZEND_ARG_INFO(pass_by_ref, name)``
+    * - No type, with default
+      - ``ZEND_ARG_INFO_WITH_DEFAULT_VALUE(pass_by_ref, name, "default")``
+    * - Single primitive
+      - ``ZEND_ARG_TYPE_INFO(pass_by_ref, name, IS_LONG, allow_null)``
+    * - Single primitive, with default
+      - ``ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(pass_by_ref, name, IS_LONG, 0, "42")``
+    * - Primitive bitmask
+      - ``ZEND_ARG_TYPE_MASK(pass_by_ref, name, MAY_BE_LONG|MAY_BE_NULL, "null")``
+    * - Object / class
+      - ``ZEND_ARG_OBJ_INFO(pass_by_ref, name, ClassName, allow_null)``
+    * - Object + primitives
+      - ``ZEND_ARG_OBJ_TYPE_MASK(pass_by_ref, name, ClassName, MAY_BE_FALSE, "null")``
+    * - Variadic, no type
+      - ``ZEND_ARG_VARIADIC_INFO(pass_by_ref, name)``
+
+Declaring classes, interfaces, and enums
+-----------------------------------------
+
+Stub files can also declare classes, interfaces, and enums. The ``/** @generate-class-entries */`` doc
+comment instructs ``gen_stub.php`` to generate a ``register_class_*()`` function::
+
+    <?php
+
+    /** @generate-class-entries */
+
+    class MyExtException extends RuntimeException {
+        public function __construct(
+            string $message = "",
+            int $code = 0,
+            ?Throwable $previous = null
+        ) {}
+    }
+
+    interface Compressible {
+        public function compress(int $level = -1): string;
+    }
+
+The generated header will include::
+
+    static zend_class_entry *register_class_MyExtException(
+        zend_class_entry *class_entry_RuntimeException);
+
+    static zend_class_entry *register_class_Compressible(void);
+
+In your MINIT, call these functions to actually register the classes::
+
+    PHP_MINIT_FUNCTION(myext)
+    {
+        zend_class_entry *ce = register_class_MyExtException(
+            zend_ce_runtime_exception);
+        /* save ce if needed */
+
+        register_class_Compressible();
+
+        return SUCCESS;
+    }
+
+Declaring constants
+--------------------
+
+Constants in stub files use ``UNKNOWN`` as a placeholder value. The engine cannot infer the value from
+a C ``#define``, so you still register constants in MINIT as usual, but the stub declares their names
+and types for reflection::
+
+    <?php
+
+    /** @generate-class-entries */
+
+    /* Module-level constants */
+    const MYEXT_VERSION = UNKNOWN;
+    const MYEXT_FLAG_FAST = UNKNOWN;
+
+``gen_stub.php`` generates a ``register_myext_symbols()`` function that you call from MINIT::
+
+    PHP_MINIT_FUNCTION(myext)
+    {
+        register_myext_symbols(module_number);
+        /* ... */
+        return SUCCESS;
+    }
+
+The generated registration function uses ``REGISTER_LONG_CONSTANT`` and similar macros, but with the
+actual value set to ``MYEXT_VERSION`` -- the C preprocessor symbol of the same name. So you must ensure
+that a C macro of the same name is defined before the generated header is included.
+
+Readonly properties
+--------------------
+
+.. versionadded:: PHP 8.1
+
+PHP 8.1 readonly properties can be declared in stub files using the ``readonly`` keyword::
+
+    class MyValue {
+        public readonly int $value;
+        public function __construct(int $value) {}
+    }
+
+The generated ``register_class_MyValue()`` function will use ``ZEND_ACC_READONLY`` when declaring the
+property with ``zend_declare_property``.
+
+Migrating from PHP 7 hand-written arginfo
+------------------------------------------
+
+If you have an existing PHP 7 extension with hand-written arginfo, here is the migration path:
+
+1. Create a ``.stub.php`` file that describes your functions in PHP syntax.
+2. Run ``gen_stub.php`` to generate the ``*_arginfo.h`` file.
+3. Replace your hand-written arginfo with ``#include "myext_arginfo.h"``.
+4. Replace your ``zend_function_entry myext_functions[]`` table with the generated ``ext_functions[]``.
+5. If you use named arguments in any of your functions, ensure the parameter names in the stub match
+   the names you want to expose to PHP code.
+
+The most common issues during migration are:
+
+* **String/false return types**: These must use ``ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX`` with
+  ``MAY_BE_STRING|MAY_BE_FALSE``, not the old ``ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX`` with
+  ``IS_STRING, 1``.
+
+* **Parameter names**: PHP 7 arginfo often used ``""`` (empty string) as the parameter name.
+  Named arguments require real names. The stub file always uses the real names.
+
+* **Return by reference**: The ``return_ref`` argument to ``ZEND_BEGIN_ARG_*`` macros controls whether
+  the function can return by reference. Most functions pass ``0`` here.

--- a/Book/php7/fibers.rst
+++ b/Book/php7/fibers.rst
@@ -1,0 +1,21 @@
+Fibers
+======
+
+.. versionadded:: PHP 8.1
+
+   Fibers were introduced in PHP 8.1 and are not available in PHP 7.
+
+PHP 8.1 introduced fibers as a first-class language feature. A fiber is a lightweight cooperative
+coroutine: it can suspend its execution at any point (calling ``Fiber::suspend()``), return a value to
+the code that resumed it, and later be resumed from where it left off.
+
+Fibers are the foundation for asynchronous PHP frameworks (such as ReactPHP and Revolt) and provide a
+clean model for writing non-blocking code without callback hell.
+
+This chapter covers the internal implementation of fibers, their C API, and what extension authors must
+be aware of.
+
+.. toctree::
+    :maxdepth: 2
+
+    fibers/internals.rst

--- a/Book/php7/fibers/internals.rst
+++ b/Book/php7/fibers/internals.rst
@@ -1,0 +1,276 @@
+Fiber internals
+===============
+
+.. versionadded:: PHP 8.1
+
+   This chapter describes PHP 8.1+ fiber internals. The fiber infrastructure does not exist in PHP 7.
+
+This chapter covers the internal implementation of fibers. It explains the data structures, the
+context-switching mechanism, and the C API available to extensions.
+
+The two-level fiber design
+---------------------------
+
+PHP fibers are built on two layers:
+
+* **``zend_fiber_context``** is the low-level coroutine primitive. It owns a C stack and can switch
+  CPU execution to another context. It is not a PHP object. Event-loop libraries (such as Revolt) use
+  ``zend_fiber_context`` directly to implement their own scheduler without the overhead of PHP objects.
+
+* **``zend_fiber``** is the PHP ``Fiber`` class object. It wraps a ``zend_fiber_context``, owns a PHP
+  VM stack, and implements the ``start()``/``resume()``/``suspend()``/``getReturn()`` interface visible
+  to PHP code.
+
+This separation means that the fiber coroutine infrastructure can be used from C without being tied to
+the PHP ``Fiber`` class.
+
+The ``zend_fiber_context`` structure
+--------------------------------------
+
+Defined in ``Zend/zend_fibers.h``::
+
+    struct _zend_fiber_context {
+        void *handle;          /* platform context handle (ucontext_t* or fcontext_t) */
+        void *kind;            /* pointer identifying context type (e.g. class entry) */
+        zend_fiber_coroutine function;  /* entry point coroutine function */
+        zend_fiber_clean      cleanup;  /* destructor called when context is destroyed */
+        zend_fiber_stack     *stack;    /* the C stack for this context */
+        zend_fiber_status     status;
+        zend_execute_data    *top_observed_frame; /* for stack walkers / profilers */
+        void *reserved[ZEND_MAX_RESERVED_RESOURCES]; /* hook for extension data */
+    };
+
+The status values::
+
+    ZEND_FIBER_STATUS_INIT       /* created, not yet started */
+    ZEND_FIBER_STATUS_RUNNING    /* currently on-CPU */
+    ZEND_FIBER_STATUS_SUSPENDED  /* suspended, can be resumed */
+    ZEND_FIBER_STATUS_DEAD       /* finished or threw an unhandled exception */
+
+The ``kind`` pointer is the distinguishing mechanism. PHP ``Fiber`` objects set ``kind`` to
+``&zend_fiber_class`` (the class entry for the ``Fiber`` class). Custom contexts created by event-loop
+libraries use their own pointer. This allows stack walkers and profilers to identify whether a context
+belongs to a PHP fiber or a library-defined lightweight coroutine.
+
+The ``reserved`` array is an extension hook point. Each slot is a ``void*`` that the engine initializes
+to ``NULL``. Extensions can use ``zend_get_resource_handle()`` to claim a slot and then store per-context
+data there.
+
+The ``zend_fiber`` structure
+-----------------------------
+
+The PHP ``Fiber`` object wraps a ``zend_fiber_context``::
+
+    struct _zend_fiber {
+        zend_object       std;        /* MUST be first -- enables object <-> fiber casting */
+        uint8_t           flags;      /* ZEND_FIBER_FLAG_* bitmask */
+        zend_fiber_context context;   /* the fiber's own coroutine context */
+        zend_fiber_context *caller;   /* context that resumed this fiber */
+        zend_fiber_context *previous; /* previous context in the resume chain */
+        zend_fcall_info       fci;
+        zend_fcall_info_cache fci_cache;
+        zend_execute_data    *execute_data;   /* fiber's current execute_data frame */
+        zend_execute_data    *stack_bottom;   /* bottom of fiber's VM stack */
+        zend_vm_stack         vm_stack;       /* fiber's own VM stack */
+        zval                  result;         /* value passed between suspend/resume */
+    };
+
+Fiber flags::
+
+    ZEND_FIBER_FLAG_THREW     = 1 << 0   /* threw an unhandled exception */
+    ZEND_FIBER_FLAG_BAILOUT   = 1 << 1   /* fatal error inside the fiber */
+    ZEND_FIBER_FLAG_DESTROYED = 1 << 2   /* fiber is being destroyed */
+
+Because ``std`` is the first member, you can cast between ``zend_object*`` and ``zend_fiber*`` directly::
+
+    zend_object *obj = /* a PHP Fiber instance */;
+    zend_fiber *fiber = (zend_fiber *) obj;
+
+VM state capture and restore
+------------------------------
+
+Each fiber maintains a completely separate PHP VM stack. When the engine switches to a fiber, it
+snapshots the current VM state into a temporary struct and replaces it with the fiber's state.
+
+The ``zend_fiber_vm_state`` struct (internal to ``zend_fibers.c``) stores::
+
+    zend_vm_stack      vm_stack;
+    zval              *vm_stack_top;
+    zval              *vm_stack_end;
+    size_t             vm_stack_page_size;
+    zend_execute_data *current_execute_data;
+    int                error_reporting;
+    uint32_t           jit_trace_num;
+    JMP_BUF           *bailout;
+    zend_fiber        *active_fiber;
+
+``zend_fiber_capture_vm_state()`` snapshots the current ``EG(...)`` (executor globals) into this struct.
+``zend_fiber_restore_vm_state()`` writes them back. Each switch involves one capture and one restore.
+
+Stack allocation
+-----------------
+
+Each fiber gets its own C stack. The size is configurable with the ``fiber.stack_size`` php.ini
+directive. Default sizes::
+
+    ZEND_FIBER_DEFAULT_C_STACK_SIZE = 4096 * (sizeof(void*) < 8 ? 256 : 512)
+    /* = 1 MB on 32-bit, 2 MB on 64-bit */
+
+The C stack is allocated with ``mmap`` (on Unix) or ``VirtualAlloc`` (on Windows). Guard pages
+(``ZEND_FIBER_GUARD_PAGES = 1`` page) are placed at the bottom of the stack to catch overflow with a
+SIGSEGV/SIGBUS before corruption occurs.
+
+Each fiber also gets its own PHP VM stack (``ZEND_FIBER_VM_STACK_SIZE = 1024 * sizeof(zval)``), which
+is separate from the C stack and used by the Zend executor for PHP function call frames.
+
+The context switch mechanism
+-----------------------------
+
+The actual CPU context switch is performed by ``zend_fiber_switch_context()``. The implementation
+supports two backends:
+
+**Boost.Context (default on most platforms)**
+    Uses hand-written assembly routines ``make_fcontext`` and ``jump_fcontext`` for maximum performance.
+    Handles Intel CET (shadow stacks) on modern Linux. Supported on x86_64, i386, AArch64, and ARM.
+
+**POSIX ``ucontext``** (fallback)
+    Uses POSIX ``makecontext()`` / ``swapcontext()``. Slower due to signal mask management, but
+    universally available. Used when Boost.Context is not available for the target platform.
+
+A simplified view of ``zend_fiber_switch_context()``::
+
+    void zend_fiber_switch_context(zend_fiber_transfer *transfer)
+    {
+        zend_fiber_context *from = EG(current_fiber_context);
+        zend_fiber_context *to = transfer->context;
+        zend_fiber_vm_state state;
+
+        zend_observer_fiber_switch_notify(from, to); /* notify observers */
+
+        zend_fiber_capture_vm_state(&state);         /* snapshot EG(...) */
+
+        to->status = ZEND_FIBER_STATUS_RUNNING;
+        if (from->status == ZEND_FIBER_STATUS_RUNNING)
+            from->status = ZEND_FIBER_STATUS_SUSPENDED;
+
+        transfer->context = from;                    /* tell destination who switched to it */
+        EG(current_fiber_context) = to;
+
+        /* ---- platform context switch happens here ---- */
+        /* On return, another fiber has switched back to us */
+
+        to = transfer->context;
+        EG(current_fiber_context) = from;
+        zend_fiber_restore_vm_state(&state);         /* restore EG(...) */
+
+        if (to->status == ZEND_FIBER_STATUS_DEAD)
+            zend_fiber_destroy_context(to);
+    }
+
+The ``zend_fiber_transfer`` struct is allocated on the C stack and passed as the communication channel
+between two sides of a switch::
+
+    typedef struct _zend_fiber_transfer {
+        zend_fiber_context *context;    /* IN: context to switch TO; OUT: who switched to us */
+        zval                value;      /* value passed between suspend/resume */
+        uint8_t             flags;      /* ZEND_FIBER_TRANSFER_FLAG_ERROR etc. */
+    } zend_fiber_transfer;
+
+Each fiber's entry point is ``zend_fiber_trampoline()``, which receives the initial ``transfer``,
+calls ``context->function(&transfer)``, marks the context dead, and performs a final switch back to
+the caller.
+
+The public C API
+-----------------
+
+**Context lifecycle**::
+
+    /* Initialize a context: allocate stack and set up entry function.
+     * kind: a unique pointer identifying this context type (e.g. your class entry).
+     * coroutine: the entry function, called on first switch.
+     * stack_size: 0 means use the default. */
+    ZEND_API zend_result zend_fiber_init_context(
+        zend_fiber_context     *context,
+        void                   *kind,
+        zend_fiber_coroutine    coroutine,
+        size_t                  stack_size);
+
+    /* Free the stack and clean up */
+    ZEND_API void zend_fiber_destroy_context(zend_fiber_context *context);
+
+    /* Perform the CPU + VM state switch */
+    ZEND_API void zend_fiber_switch_context(zend_fiber_transfer *transfer);
+
+**Stack introspection**::
+
+    ZEND_API void *zend_fiber_stack_limit(zend_fiber_stack *stack);
+    ZEND_API void *zend_fiber_stack_base(zend_fiber_stack *stack);
+
+**Switch blocking** (to prevent context switches in signal handlers, destructors, etc.)::
+
+    ZEND_API void zend_fiber_switch_block(void);
+    ZEND_API void zend_fiber_switch_unblock(void);
+    ZEND_API bool zend_fiber_switch_blocked(void);
+
+**PHP-level Fiber object API**::
+
+    ZEND_API zend_result zend_fiber_start(zend_fiber *fiber, zval *return_value);
+    ZEND_API void zend_fiber_resume(zend_fiber *fiber, zval *value, zval *return_value);
+    ZEND_API void zend_fiber_suspend(zend_fiber *fiber, zval *value, zval *return_value);
+
+**Type conversions**::
+
+    static inline zend_fiber *zend_fiber_from_context(zend_fiber_context *context);
+    static inline zend_fiber_context *zend_fiber_get_context(zend_fiber *fiber);
+
+The coroutine function signature
+---------------------------------
+
+If you create your own contexts with ``zend_fiber_init_context()``, the entry function must match::
+
+    typedef void (*zend_fiber_coroutine)(zend_fiber_transfer *transfer);
+
+Inside the coroutine, use the ``transfer`` to communicate with the switcher and to perform the next
+context switch when you are ready to suspend::
+
+    static void my_coroutine(zend_fiber_transfer *transfer)
+    {
+        /* transfer->value contains the value passed on start/resume */
+        zval *received = &transfer->value;
+
+        /* Do some work ... */
+
+        /* Suspend: switch back to whoever started us, passing a value */
+        ZVAL_LONG(&transfer->value, 42);
+        zend_fiber_switch_context(transfer);
+
+        /* Resume: we get here when someone switches back to us */
+        /* transfer->value now contains the resume value */
+
+        /* Final return: mark dead and switch back */
+        /* (zend_fiber_trampoline does this automatically for Fiber objects) */
+    }
+
+Implications for extensions
+-----------------------------
+
+Extension code that runs inside a PHP function call may now execute inside a fiber. This has several
+implications:
+
+**Stack walking**: When walking the PHP call stack (e.g. for backtraces), you must account for fiber
+boundaries. Use ``zend_fiber_context.top_observed_frame`` to find the top frame of a suspended fiber.
+
+**Globals**: Each fiber has its own VM stack and ``current_execute_data``, but shares the global
+executor globals (``EG(...)``). Globals such as ``EG(exception)`` are per-request, not per-fiber.
+
+**Observers**: If your extension uses the :doc:`Observer API <../extensions_design/observer_api>`,
+register fiber switch callbacks with ``zend_observer_fiber_switch_register()`` so you can correctly
+attribute time and call depth to individual fibers.
+
+**Per-fiber data**: Use the ``reserved[]`` array in ``zend_fiber_context`` to store per-context data.
+Claim a slot with ``zend_get_resource_handle()`` and access it as
+``EG(current_fiber_context)->reserved[slot]``.
+
+**Switch blocking**: If your code must not be interrupted by a fiber switch (e.g. in a destructor that
+manipulates global state), call ``zend_fiber_switch_block()`` before the critical section and
+``zend_fiber_switch_unblock()`` after.

--- a/Book/php7/internal_types.rst
+++ b/Book/php7/internal_types.rst
@@ -12,3 +12,4 @@ Contents:
     internal_types/zend_resources.rst
     internal_types/hashtables.rst
     internal_types/functions.rst
+    internal_types/type_system.rst

--- a/Book/php7/internal_types/type_system.rst
+++ b/Book/php7/internal_types/type_system.rst
@@ -1,0 +1,308 @@
+The type system
+===============
+
+.. versionadded:: PHP 8.0
+
+   The ``zend_type`` structure described here was introduced in PHP 8.0. PHP 7 used separate
+   ``type_hint`` and ``class_name`` fields in ``zend_internal_arg_info``. Union types, intersection
+   types, and DNF types are PHP 8.0+ features.
+
+PHP 8 introduced a significantly more expressive type system. From a user perspective, PHP 8.0 added union
+types (``int|string``), PHP 8.1 added intersection types (``Countable&Iterator``) and the ``never`` return
+type, and PHP 8.2 added standalone ``null``, ``true``, and ``false`` types as well as DNF (disjunctive normal
+form) types (``(Countable&Iterator)|null``).
+
+Internally, all of this is represented through the ``zend_type`` structure and the ``MAY_BE_*`` bitmask
+family. This chapter explains how these work and how to use them in extension code.
+
+The ``zend_type`` structure
+----------------------------
+
+Every type hint in PHP -- whether on a function parameter, return value, or property -- is represented by a
+``zend_type`` value. The structure is defined in ``Zend/zend_types.h``::
+
+    typedef struct {
+        void    *ptr;
+        uint32_t type_mask;
+    } zend_type;
+
+The two fields serve different roles depending on what type is being represented:
+
+* **``type_mask``** is a bitmask. The lower 18 bits are ``MAY_BE_*`` flags (one bit per primitive type).
+  The upper bits encode metadata: whether ``ptr`` points to a class name or type list, whether the type
+  list is a union or intersection, and so on.
+
+* **``ptr``** points to auxiliary data when needed. For a class/interface type it points to a
+  ``zend_string*`` (or a ``const char*`` for internal functions). For union and intersection types it
+  points to a ``zend_type_list``.
+
+For pure primitive types (e.g. ``int``, ``string``, ``?bool``), ``ptr`` is ``NULL`` and the entire type
+is encoded in ``type_mask``.
+
+The ``zend_type_list`` structure
+---------------------------------
+
+Union and intersection types use a type list::
+
+    typedef struct {
+        uint32_t  num_types;
+        zend_type types[1]; /* flexible array */
+    } zend_type_list;
+
+Each element of the ``types`` array is itself a ``zend_type``, which may represent a primitive type, a
+named class type, or (for DNF types) another list. The ``type_mask`` of the enclosing ``zend_type``
+carries the ``_ZEND_TYPE_UNION_BIT`` or ``_ZEND_TYPE_INTERSECTION_BIT`` flag to indicate which kind
+of compound type this is.
+
+The ``MAY_BE_*`` bitmask family
+--------------------------------
+
+The lower 18 bits of ``type_mask`` (bits 0-17) are ``MAY_BE_*`` flags, one per PHP type. These flags are
+also used extensively by the optimizer and JIT for type inference, though some bits are only valid in type
+declarations and not in the optimizer's type information. They are defined in ``Zend/zend_type_info.h``::
+
+    #define MAY_BE_UNDEF     (1 << IS_UNDEF)    /* bit 0  */
+    #define MAY_BE_NULL      (1 << IS_NULL)      /* bit 1  */
+    #define MAY_BE_FALSE     (1 << IS_FALSE)     /* bit 2  */
+    #define MAY_BE_TRUE      (1 << IS_TRUE)      /* bit 3  */
+    #define MAY_BE_BOOL      (MAY_BE_FALSE|MAY_BE_TRUE)
+    #define MAY_BE_LONG      (1 << IS_LONG)      /* bit 4  */
+    #define MAY_BE_DOUBLE    (1 << IS_DOUBLE)    /* bit 5  */
+    #define MAY_BE_STRING    (1 << IS_STRING)    /* bit 6  */
+    #define MAY_BE_ARRAY     (1 << IS_ARRAY)     /* bit 7  */
+    #define MAY_BE_OBJECT    (1 << IS_OBJECT)    /* bit 8  */
+    #define MAY_BE_RESOURCE  (1 << IS_RESOURCE)  /* bit 9  */
+    #define MAY_BE_ANY       (MAY_BE_NULL|MAY_BE_FALSE|MAY_BE_TRUE|MAY_BE_LONG| \
+                              MAY_BE_DOUBLE|MAY_BE_STRING|MAY_BE_ARRAY|          \
+                              MAY_BE_OBJECT|MAY_BE_RESOURCE)
+    #define MAY_BE_REF       (1 << IS_REFERENCE) /* bit 10 */
+
+The following bits exist at positions 11-17 and are only meaningful in type declarations (not in the
+optimizer's ``MAY_BE_*`` usage)::
+
+    #define MAY_BE_CALLABLE  (1 << IS_CALLABLE)
+    #define MAY_BE_VOID      (1 << IS_VOID)
+    #define MAY_BE_NEVER     (1 << IS_NEVER)
+    #define MAY_BE_STATIC    (1 << IS_STATIC)
+
+Notice that ``MAY_BE_ANY`` does not include ``MAY_BE_UNDEF`` or ``MAY_BE_REF``. The ``mixed`` type maps
+to ``MAY_BE_ANY``, not ``MAY_BE_ANY | MAY_BE_NULL`` -- ``null`` is already in ``MAY_BE_ANY``.
+
+``type_mask`` bit layout
+-------------------------
+
+The 32 bits of ``type_mask`` are partitioned as follows:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 30 60
+
+    * - Bits
+      - Name
+      - Purpose
+    * - 0--17
+      - ``MAY_BE_*``
+      - Primitive type flags (see above)
+    * - 18
+      - ``_ZEND_TYPE_UNION_BIT``
+      - ``ptr`` points to a union type list
+    * - 19
+      - ``_ZEND_TYPE_INTERSECTION_BIT``
+      - ``ptr`` points to an intersection type list
+    * - 20
+      - ``_ZEND_TYPE_ARENA_BIT``
+      - Type list is arena-allocated (persistent)
+    * - 21
+      - ``_ZEND_TYPE_ITERABLE_BIT``
+      - BC compatibility flag for the ``iterable`` pseudo-type
+    * - 22
+      - ``_ZEND_TYPE_LIST_BIT``
+      - ``ptr`` is a ``zend_type_list*``
+    * - 23
+      - ``_ZEND_TYPE_LITERAL_NAME_BIT``
+      - ``ptr`` is a ``const char*`` class name (internal functions)
+    * - 24
+      - ``_ZEND_TYPE_NAME_BIT``
+      - ``ptr`` is a ``zend_string*`` class name
+    * - 25--31
+      - Extra flags
+      - Per-argument flags (pass-by-ref, variadic, tentative; see arginfo)
+
+The bit at position 1 (``MAY_BE_NULL``) doubles as the "nullable" flag: checking
+``type_mask & _ZEND_TYPE_NULLABLE_BIT`` is equivalent to checking ``type_mask & MAY_BE_NULL``.
+
+Inspection macros
+-----------------
+
+The engine provides a complete set of macros to inspect a ``zend_type`` without accessing the struct
+members directly. Always use these macros rather than reading ``ptr`` and ``type_mask`` directly.
+
+**Presence checks**::
+
+    ZEND_TYPE_IS_SET(t)          /* is any type hint present at all? */
+    ZEND_TYPE_IS_ONLY_MASK(t)    /* only primitive MAY_BE_* bits, no ptr */
+    ZEND_TYPE_IS_COMPLEX(t)      /* has a class name or type list pointer */
+
+**Kind checks**::
+
+    ZEND_TYPE_HAS_NAME(t)        /* ptr is a zend_string* class name */
+    ZEND_TYPE_HAS_LITERAL_NAME(t)/* ptr is a const char* class name */
+    ZEND_TYPE_HAS_LIST(t)        /* ptr is a zend_type_list* */
+    ZEND_TYPE_IS_UNION(t)        /* compound type is a union */
+    ZEND_TYPE_IS_INTERSECTION(t) /* compound type is an intersection */
+
+**Nullable / mask access**::
+
+    ZEND_TYPE_ALLOW_NULL(t)      /* is null allowed? */
+    ZEND_TYPE_PURE_MASK(t)       /* MAY_BE_* bits only (bits 0-17) */
+    ZEND_TYPE_FULL_MASK(t)       /* entire type_mask value */
+
+**Pointer access** (use only after the corresponding check)::
+
+    ZEND_TYPE_NAME(t)            /* (zend_string *) class name */
+    ZEND_TYPE_LITERAL_NAME(t)    /* (const char *) class name */
+    ZEND_TYPE_LIST(t)            /* (zend_type_list *) compound type list */
+
+**Primitive type check**::
+
+    ZEND_TYPE_CONTAINS_CODE(t, IS_LONG)   /* does type include IS_LONG? */
+    ZEND_TYPE_CONTAINS_CODE(t, IS_STRING) /* does type include IS_STRING? */
+
+**Iteration over compound types**::
+
+    zend_type *type_ptr;
+
+    ZEND_TYPE_FOREACH(my_type, type_ptr) {
+        /* *type_ptr is each constituent zend_type */
+    } ZEND_TYPE_FOREACH_END();
+
+    /* For a known zend_type_list: */
+    ZEND_TYPE_LIST_FOREACH(list_ptr, type_ptr) {
+        /* *type_ptr is each element */
+    } ZEND_TYPE_LIST_FOREACH_END();
+
+Construction macros
+--------------------
+
+When writing arginfo by hand (or when understanding what ``gen_stub.php`` generates), the following
+construction macros are used:
+
+**No type hint**::
+
+    ZEND_TYPE_INIT_NONE(extra_flags)
+
+**Single primitive type** (the most common case)::
+
+    ZEND_TYPE_INIT_CODE(IS_LONG, /* allow_null */ 0, /* extra_flags */ 0)
+    ZEND_TYPE_INIT_CODE(IS_STRING, 1, 0)  /* nullable string */
+    ZEND_TYPE_INIT_CODE(_IS_BOOL, 0, 0)   /* bool */
+    ZEND_TYPE_INIT_CODE(IS_VOID, 0, 0)    /* void return */
+
+**Bitmask of primitives** (for unions of primitive types)::
+
+    ZEND_TYPE_INIT_MASK(MAY_BE_STRING | MAY_BE_FALSE)
+    ZEND_TYPE_INIT_MASK(MAY_BE_LONG | MAY_BE_NULL)
+
+**Class type**::
+
+    /* For internal functions using a const char* name: */
+    ZEND_TYPE_INIT_CLASS_CONST("SomeClass", /* allow_null */ 0, 0)
+
+    /* For user-defined functions using a zend_string* name: */
+    ZEND_TYPE_INIT_CLASS(name_zstr, 0, 0)
+
+    /* Class + primitive union (e.g. SomeClass|false): */
+    ZEND_TYPE_INIT_CLASS_CONST_MASK("SomeClass", MAY_BE_FALSE)
+
+**Compound type (union or intersection)**::
+
+    ZEND_TYPE_INIT_UNION(list_ptr, extra_flags)
+    ZEND_TYPE_INIT_INTERSECTION(list_ptr, extra_flags)
+
+Representing common PHP 8 types
+---------------------------------
+
+The table below shows how common PHP 8 type declarations map to ``zend_type`` internal representation:
+
+.. list-table::
+    :header-rows: 1
+
+    * - PHP type declaration
+      - ``type_mask`` value
+      - ``ptr``
+    * - ``int``
+      - ``MAY_BE_LONG``
+      - ``NULL``
+    * - ``?int``
+      - ``MAY_BE_LONG | MAY_BE_NULL``
+      - ``NULL``
+    * - ``string|false``
+      - ``MAY_BE_STRING | MAY_BE_FALSE``
+      - ``NULL``
+    * - ``mixed``
+      - ``MAY_BE_ANY``
+      - ``NULL``
+    * - ``void``
+      - ``MAY_BE_VOID``
+      - ``NULL``
+    * - ``never``
+      - ``MAY_BE_NEVER``
+      - ``NULL``
+    * - ``bool``
+      - ``MAY_BE_BOOL``
+      - ``NULL``
+    * - ``callable``
+      - ``MAY_BE_CALLABLE``
+      - ``NULL``
+    * - ``Foo``
+      - ``_ZEND_TYPE_LITERAL_NAME_BIT``
+      - ``(const char *) "Foo"``
+    * - ``?Foo``
+      - ``_ZEND_TYPE_LITERAL_NAME_BIT | MAY_BE_NULL``
+      - ``(const char *) "Foo"``
+    * - ``int|string``
+      - ``_ZEND_TYPE_LIST_BIT | _ZEND_TYPE_UNION_BIT``
+      - ``(zend_type_list *)``
+    * - ``Countable&Iterator``
+      - ``_ZEND_TYPE_LIST_BIT | _ZEND_TYPE_INTERSECTION_BIT``
+      - ``(zend_type_list *)``
+
+Checking types at runtime
+--------------------------
+
+To check whether a given ``zval`` satisfies a ``zend_type`` constraint, use ``zend_check_type()`` from
+``Zend/zend_types.h``. In practice, extension code rarely needs to do this manually -- the parameter
+parsing macros and the engine's type coercion handle it automatically when a PHP function is called.
+
+However, if you are implementing a custom property handler or need type checking outside of the normal
+call mechanism, you can use::
+
+    bool zend_value_instanceof_static(zval *zv);
+    bool zend_check_type(zend_type *type, zval *arg, void **cache_slot,
+                         zend_class_entry *scope, bool is_return_type,
+                         bool is_internal);
+
+Arginfo and property types
+---------------------------
+
+``zend_type`` is used in three places:
+
+1. **Function/method arginfo** (parameter and return types) -- via ``zend_arg_info.type`` /
+   ``zend_internal_arg_info.type``.
+
+2. **Property type declarations** -- via ``zend_property_info.type``.
+
+3. **Class constant type declarations** (PHP 8.3+) -- via ``zend_class_constant.type``.
+
+The :doc:`stub files chapter <../extensions_design/stub_files>` explains how to declare all of these
+in extension code using the stub file approach.
+
+The ``iterable`` pseudo-type
+------------------------------
+
+The ``iterable`` pseudo-type (equivalent to ``array|Traversable``) is represented with the
+``_ZEND_TYPE_ITERABLE_BIT`` flag for backward compatibility. In PHP 8.2 and later, ``iterable`` is a
+compile-time alias for ``array|Traversable`` in user-defined functions. In arginfo for internal functions,
+you can use ``IS_ITERABLE`` with ``ZEND_TYPE_INIT_CODE`` and it will be handled correctly::
+
+    ZEND_TYPE_INIT_CODE(IS_ITERABLE, 0, 0)

--- a/Book/php7/introduction.rst
+++ b/Book/php7/introduction.rst
@@ -43,3 +43,32 @@ The repository for this book is available on GitHub_. Please report issues and p
 
 .. _GitHub: https://github.com/phpinternalsbook/PHP-Internals-Book
 .. _issue tracker: https://github.com/phpinternalsbook/PHP-Internals-Book/issues
+
+PHP 8 and the 8.x series
+-------------------------
+
+.. versionadded:: PHP 8.0
+
+This section of the book also covers PHP 8 and the subsequent 8.x releases. PHP 8 is built
+directly on the PHP 7 foundation. The core data structures -- zvals, hashtables, ``zend_string``,
+and the Zend memory manager -- are unchanged. Most chapters apply equally to both versions.
+
+Where behaviour or APIs changed in PHP 8, the differences are explicitly noted inline with a
+coloured callout box stating the PHP version in which the change was introduced. Sections that
+cover concepts that exist only in PHP 8 (fibers, enums, the JIT compiler, attributes, the
+observer API) carry such a notice at the very top of the section.
+
+The PHP 8.x release timeline:
+
+* **PHP 8.0** (November 2020) -- JIT compiler, union types, named arguments, attributes,
+  match expressions, constructor property promotion. Object handlers API cleaned up (now
+  accept ``zend_object*`` instead of ``zval*``). TSRM compatibility macros removed. All
+  internal functions now required to declare arginfo.
+* **PHP 8.1** (November 2021) -- Fibers (coroutines), enums, readonly properties,
+  intersection types, first-class callable syntax, ``never`` return type.
+* **PHP 8.2** (December 2022) -- Readonly classes, disjunctive normal form (DNF) types,
+  standalone ``null``/``true``/``false`` types.
+* **PHP 8.3** (November 2023) -- Typed class constants, ``#[\Override]`` attribute. C99
+  compiler formalised as a hard requirement.
+* **PHP 8.4** (November 2024) -- Property hooks, asymmetric visibility,
+  ``#[\Deprecated]`` attribute, frameless function calls for faster internal dispatch.

--- a/Book/php7/zend_engine.rst
+++ b/Book/php7/zend_engine.rst
@@ -15,4 +15,5 @@ Contents:
     zend_engine/zend_compiler.rst
     zend_engine/zend_executor.rst
     zend_engine/zend_opcache.rst
+    zend_engine/jit.rst
 

--- a/Book/php7/zend_engine/jit.rst
+++ b/Book/php7/zend_engine/jit.rst
@@ -1,0 +1,320 @@
+JIT compiler
+============
+
+.. versionadded:: PHP 8.0
+
+   The JIT compiler was introduced in PHP 8.0 as part of the opcache extension. It is not present in
+   PHP 7.
+
+PHP 8.0 introduced a JIT (Just-In-Time) compiler, integrated as part of the opcache extension. The JIT
+converts PHP opcodes into native machine code at runtime, bypassing the Zend VM interpreter for hot code
+paths. For CPU-bound workloads, the JIT can provide significant performance improvements.
+
+The JIT is not a standalone extension -- it is embedded in ``ext/opcache`` and requires opcache to be
+enabled. It is inactive unless explicitly configured with a non-zero ``opcache.jit_buffer_size`` and
+an appropriate ``opcache.jit`` setting.
+
+Architecture overview
+---------------------
+
+The JIT compilation pipeline is::
+
+    PHP source → Zend opcodes
+                     ↓
+              opcache Optimizer (CFG, SSA, type inference)
+                     ↓
+              zend_jit_op_array() / zend_jit_script()
+                     ↓
+              IR framework (SCCP, GCM, reg-alloc, codegen)
+                     ↓
+              Native machine code in shared memory buffer
+
+The optimizer performs static analysis -- building a control flow graph (CFG), constructing SSA form,
+and running type inference. The JIT uses these results to emit specialized native code. Higher optimization
+levels perform more extensive analysis, including inter-procedural analysis across entire scripts.
+
+The JIT is built on an embedded version of the **IR framework** (a lightweight JIT compilation framework)
+from `github.com/dstogov/ir <https://github.com/dstogov/ir>`_. The IR framework handles scheduling,
+register allocation, and code generation for the supported architectures: x86_64, i386, and AArch64.
+
+JIT modes
+----------
+
+The ``opcache.jit`` setting accepts either a named alias or a 4-digit number ``ABCD``.
+
+Named aliases:
+
+.. list-table::
+    :header-rows: 1
+
+    * - Value
+      - Mode
+      - Description
+    * - ``disable``
+      - Disabled
+      - JIT infrastructure is not loaded. Cannot be re-enabled at runtime.
+    * - ``off`` / ``0`` / ``false``
+      - Off
+      - Infrastructure loaded but not compiling.
+    * - ``tracing`` / ``on`` / ``1`` / ``true``
+      - Tracing JIT (default)
+      - Compiles hot traces after a threshold number of executions.
+    * - ``function``
+      - Function JIT
+      - Compiles entire functions at opcache load time.
+
+The **tracing JIT** is the default and is recommended for most workloads. It records execution traces
+when a loop or function becomes hot (exceeds the configured counter threshold), then compiles those
+traces to native code. It performs well on dynamic code and adapts to actual runtime types.
+
+The **function JIT** compiles entire functions ahead of time at script load. It uses more memory but
+avoids the overhead of trace recording.
+
+The 4-digit number format
+--------------------------
+
+For fine-grained control, use a 4-digit number ``ABCD``:
+
+.. list-table::
+    :header-rows: 1
+    :widths: 10 20 70
+
+    * - Digit
+      - Position
+      - Meaning
+    * - A
+      - thousands
+      - AVX usage: ``0``=disabled, ``1``=use AVX if available
+    * - B
+      - hundreds
+      - Register allocation: ``0``=none, ``1``=local LSRA, ``2``=global LSRA
+    * - C
+      - tens
+      - Trigger (when to compile; see ``ZEND_JIT_ON_*`` constants)
+    * - D
+      - units
+      - Optimization level (see ``ZEND_JIT_LEVEL_*`` constants)
+
+The trigger values (digit C):
+
+.. list-table::
+    :header-rows: 1
+
+    * - Value
+      - Constant
+      - Meaning
+    * - 0
+      - ``ZEND_JIT_ON_SCRIPT_LOAD``
+      - Compile everything at opcache load time (function JIT)
+    * - 1
+      - ``ZEND_JIT_ON_FIRST_EXEC``
+      - Compile on first execution of the function
+    * - 2
+      - ``ZEND_JIT_ON_PROF_REQUEST``
+      - Compile most-called functions at the start of the first request
+    * - 3
+      - ``ZEND_JIT_ON_HOT_COUNTERS``
+      - Compile after N function calls or loop iterations
+    * - 4
+      - ``ZEND_JIT_ON_DOC_COMMENT``
+      - Compile functions with a ``@jit`` docblock annotation
+    * - 5
+      - ``ZEND_JIT_ON_HOT_TRACE``
+      - Tracing JIT: record and compile after N executions
+
+The optimization levels (digit D):
+
+.. list-table::
+    :header-rows: 1
+
+    * - Value
+      - Constant
+      - Description
+    * - 0
+      - ``ZEND_JIT_LEVEL_NONE``
+      - No JIT
+    * - 1
+      - ``ZEND_JIT_LEVEL_MINIMAL``
+      - Subroutine threading (replace VM dispatch with direct calls)
+    * - 2
+      - ``ZEND_JIT_LEVEL_INLINE``
+      - Selective inline threading
+    * - 3
+      - ``ZEND_JIT_LEVEL_OPT_FUNC``
+      - Type-inference-based optimization per function
+    * - 4
+      - ``ZEND_JIT_LEVEL_OPT_FUNCS``
+      - Type-inference + call-tree optimization
+    * - 5
+      - ``ZEND_JIT_LEVEL_OPT_SCRIPT``
+      - Type-inference + inter-procedural (whole-script) optimization
+
+For example, ``opcache.jit=1254`` means: AVX=enabled, global LSRA, trigger=HOT_COUNTERS, level=OPT_FUNCS.
+
+Key php.ini directives
+-----------------------
+
+.. list-table::
+    :header-rows: 1
+
+    * - Directive
+      - Default
+      - Description
+    * - ``opcache.jit``
+      - ``tracing``
+      - JIT mode (see above). Set to ``disable`` to prevent JIT entirely.
+    * - ``opcache.jit_buffer_size``
+      - ``0``
+      - Shared memory buffer for compiled code. Set to e.g. ``64M`` to enable. 0 = JIT off.
+    * - ``opcache.jit_debug``
+      - ``0``
+      - Bitmask of debug flags (disassembly, SSA dumps, perf/VTune/GDB integration).
+    * - ``opcache.jit_hot_loop``
+      - ``64``
+      - Loop iterations before triggering trace compilation.
+    * - ``opcache.jit_hot_func``
+      - ``127``
+      - Function calls before triggering compilation.
+    * - ``opcache.jit_max_root_traces``
+      - ``1024``
+      - Maximum number of trace entry points.
+    * - ``opcache.jit_max_side_traces``
+      - ``128``
+      - Maximum side traces per root trace.
+    * - ``opcache.jit_max_loop_unrolls``
+      - ``8``
+      - Maximum loop unroll count.
+    * - ``opcache.jit_max_recursive_calls``
+      - ``2``
+      - Inline recursion depth limit.
+    * - ``opcache.jit_max_polymorphic_calls``
+      - ``2``
+      - Polymorphic call inline limit.
+
+The ``jit_buffer_size`` must be non-zero to activate the JIT. The value is carved out of the opcache
+shared memory segment (controlled by ``opcache.memory_consumption``). Make sure
+``opcache.memory_consumption`` is large enough to accommodate both the bytecode cache and the JIT buffer.
+
+How tracing works
+------------------
+
+In tracing mode, each opline starts with a hot counter. The counter for a back-edge (loop) or function
+entry is decremented on each execution. When the counter crosses zero:
+
+1. The VM enters **trace recording** mode for that opline.
+2. Every subsequent opline executed is recorded, including observed operand types.
+3. Recording stops at a trace stop reason: back-edge of a loop (``LOOP`` stop), function return
+   (``RETURN`` stop), or one of many other conditions.
+4. The recorded trace is handed to the IR-based compiler.
+5. If compilation succeeds, the original opline handlers are patched to jump directly to the compiled
+   native code on the hot path.
+
+The trace is specialised for the observed types. If a future execution takes a different path (e.g. the
+same variable is now a string instead of an integer), a **side exit** is taken back to the interpreter.
+If a side exit becomes hot, a **side trace** is compiled for that branch.
+
+The JIT and extension compatibility
+--------------------------------------
+
+Extension authors must be aware of the following JIT compatibility requirements:
+
+**Custom opcode handlers disable the JIT**
+
+If any extension registers a custom opcode handler via ``zend_set_user_opcode_handler()``, the JIT
+disables itself entirely for that execution. The JIT cannot safely emit native code for opcodes that
+have been overridden by an extension.
+
+This affects extensions such as Xdebug (which hooks opcodes for debugging and coverage). Such extensions
+are typically incompatible with the JIT, and this is expected -- the JIT disabling is intentional.
+
+If your extension uses opcode handlers for a non-debug purpose, consider switching to the
+:doc:`Observer API <../extensions_design/observer_api>`, which is JIT-compatible.
+
+**``ZEND_EXT_API`` functions for extensions**
+
+The JIT exports two functions specifically for use by Zend extensions:
+
+``zend_jit_status(zval *ret)``
+    Fills a hash table with JIT runtime statistics (compiled functions, trace counts, etc.). Useful for
+    monitoring and diagnostics.
+
+``zend_jit_blacklist_function(zend_op_array *op_array)``
+    Permanently prevents a specific function from being JIT-compiled. Useful for debuggers and profilers
+    that need to instrument a function at the bytecode level and cannot tolerate JIT interference.
+
+**No observer interaction needed**
+
+Extensions that only use the :doc:`Observer API <../extensions_design/observer_api>` do not need to take
+any special action. The JIT respects observer hooks and does not optimise away observed calls.
+
+Debug flags
+------------
+
+The ``opcache.jit_debug`` directive is a bitmask that controls what debugging information the JIT emits.
+These flags are useful when investigating JIT behaviour or performance::
+
+    ZEND_JIT_DEBUG_ASM         (1 << 0)  /* print disassembly of compiled code */
+    ZEND_JIT_DEBUG_SSA         (1 << 1)  /* print SSA form */
+    ZEND_JIT_DEBUG_REG_ALLOC   (1 << 2)  /* register allocation dump */
+    ZEND_JIT_DEBUG_ASM_STUBS   (1 << 3)  /* print JIT helper stubs */
+    ZEND_JIT_DEBUG_PERF        (1 << 4)  /* Linux perf map integration */
+    ZEND_JIT_DEBUG_PERF_DUMP   (1 << 5)  /* perf dump file */
+    ZEND_JIT_DEBUG_VTUNE       (1 << 7)  /* Intel VTune integration */
+    ZEND_JIT_DEBUG_GDB         (1 << 8)  /* GDB JIT interface (gdb 'info functions') */
+    ZEND_JIT_DEBUG_TRACE_START (1 << 12) /* log when trace recording starts */
+    ZEND_JIT_DEBUG_TRACE_STOP  (1 << 13) /* log when recording stops and why */
+    /* ... more flags for IR optimizer pass dumps ... */
+
+To see a disassembly of all compiled code::
+
+    opcache.jit=tracing
+    opcache.jit_buffer_size=64M
+    opcache.jit_debug=1
+
+To integrate with Linux ``perf``::
+
+    opcache.jit_debug=16   ; (1 << 4)
+
+Then run::
+
+    perf record php your_script.php
+    perf report
+
+Frameless function calls (PHP 8.4)
+------------------------------------
+
+.. versionadded:: PHP 8.4
+
+PHP 8.4 introduced **frameless function calls** (``ZEND_FRAMELESS_FUNCTION``), a JIT optimization that
+allows specific internal functions to be called without creating a full ``zend_execute_data`` frame on
+the VM stack. The function receives its arguments directly via opcode operands.
+
+To make an internal function eligible for frameless calls, define a frameless handler alongside the
+regular handler. The handler receives arguments as individual parameters rather than via the standard
+call ABI::
+
+    ZEND_FRAMELESS_FUNCTION(strlen, 1)   /* "1" = single argument */
+    {
+        zval *str;
+        ZEND_FLF_ARG(str, 1);            /* fetch argument 1 */
+
+        if (Z_TYPE_P(str) != IS_STRING) {
+            /* fall back to the regular handler */
+            ZEND_FLF_NARROW_RETURN();
+            return;
+        }
+
+        RETURN_LONG(Z_STRLEN_P(str));
+    }
+
+Frameless handlers are registered alongside the regular function in the function entry::
+
+    ZEND_RAW_FENTRY("strlen", zif_strlen, arginfo_strlen, 0,
+                    ZEND_FLF_HANDLER(strlen, 1), NULL)
+
+The JIT emits ``FRAMELESS_ICALL_*`` opcodes for calls to frameless-capable functions when the argument
+types are statically known. This eliminates the frame setup/teardown overhead for short, simple internal
+functions like ``strlen``, ``count``, ``abs``, etc.
+
+Extension authors writing performance-critical internal functions that receive a small, fixed number of
+arguments may benefit from providing frameless handlers.

--- a/Book/php7/zvals/basic_structure.rst
+++ b/Book/php7/zvals/basic_structure.rst
@@ -356,3 +356,33 @@ The following table summarizes the most commonly used accessor macros, though th
 When you want to access the contents of a zval, you should always go through these macros, rather than directly
 accessing its members. This maintains a level of abstraction and will, to some degree, insulate you from changes in
 the implementation.
+
+PHP 8 type additions
+--------------------
+
+The ``zval`` structure itself is unchanged in PHP 8. The following additions affect type declarations
+and the type system only -- they never appear as the type of a runtime zval.
+
+.. versionadded:: PHP 8.1
+
+   ``IS_NEVER`` was added to represent the ``never`` return type, which declares that a function
+   never returns normally (it always throws or calls ``exit()``). This type exists only in arginfo
+   and property type declarations.
+
+.. versionadded:: PHP 8.0
+
+   ``false`` can be used as a standalone return type for internal functions. In the ``MAY_BE_*``
+   bitmask world, it maps to the existing ``MAY_BE_FALSE`` bit.
+
+.. versionadded:: PHP 8.2
+
+   ``null`` and ``true`` became standalone types alongside the already-available ``false``.
+   All three map to existing ``MAY_BE_*`` bits (``MAY_BE_NULL``, ``MAY_BE_TRUE``,
+   ``MAY_BE_FALSE``) and can appear anywhere a type hint is accepted.
+
+.. versionchanged:: PHP 8.0
+
+   The ``GC_COLLECTABLE`` flag on reference-counted values was inverted to
+   ``GC_NOT_COLLECTABLE``. Extension code that previously set ``GC_COLLECTABLE`` must be
+   updated: values that participate in circular garbage collection (the default) should
+   **not** have ``GC_NOT_COLLECTABLE`` set.


### PR DESCRIPTION
I've recently taken up PHP extension work, and in an attempt to learn more about it I've been exploring Claude code and seeing how it could help me pick this work up. The PHP7 book was somewhat outdated for development of PHP 8.x., and so:

**Full disclosure: I asked Claude code to analyze the source change logs and PHP8 docs to update the internals book.**

As 8.x doesn't diverge from 7 as much as 7 did from 5, there's no need to create a complete separate chapter. Instead, the PHP7 chapter is now a chapter describing 7 and 8 combined.

I realize this is a pretty big PR. Please let me know if you'd like me to split it up into separate PRs. That would be no trouble at all, but I wanted to gauge if this is an experiment you want to review in the first place before I do. Of course I did check the work (in as far as my knowledge of PHP internals allows me to).

